### PR TITLE
Retry serializable transactions on PostgreSQL conflict

### DIFF
--- a/zooid/events.go
+++ b/zooid/events.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"log"
@@ -16,6 +17,7 @@ import (
 	"fiatjaf.com/nostr/eventstore"
 	"fiatjaf.com/nostr/khatru"
 	"github.com/Masterminds/squirrel"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -415,8 +417,27 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 	// Use a serializable transaction so the read-decide-write-delete cycle is
 	// atomic. Without this, two concurrent goroutines could both read "no
 	// existing event", both insert, and leave duplicate replaceable events.
-	// PostgreSQL may return a serialization error under contention; in that
-	// case the client can simply retry the publish.
+	// PostgreSQL may return a serialization error (SQLSTATE 40001) under
+	// contention; the standard remedy is to retry the transaction.
+	const maxRetries = 3
+	var err error
+	for attempt := range maxRetries {
+		err = events.replaceEventOnce(evt)
+		if err == nil {
+			return nil
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "40001" {
+			log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), retrying",
+				evt.Kind, evt.Tags.GetD(), attempt+1, maxRetries)
+			continue
+		}
+		return err // non-retriable error
+	}
+	return fmt.Errorf("serialization conflict after %d retries: %w", maxRetries, err)
+}
+
+func (events *EventStore) replaceEventOnce(evt nostr.Event) error {
 	tx, err := GetDb().BeginTx(context.Background(), &sql.TxOptions{
 		Isolation: sql.LevelSerializable,
 	})

--- a/zooid/events.go
+++ b/zooid/events.go
@@ -428,9 +428,15 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 		}
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "40001" {
-			log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), retrying",
+			if attempt+1 < maxRetries {
+				log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), retrying",
+					evt.Kind, evt.Tags.GetD(), attempt+1, maxRetries)
+				time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+				continue
+			}
+			log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), giving up",
 				evt.Kind, evt.Tags.GetD(), attempt+1, maxRetries)
-			continue
+			break
 		}
 		return err // non-retriable error
 	}

--- a/zooid/events_test.go
+++ b/zooid/events_test.go
@@ -1,7 +1,10 @@
 package zooid
 
 import (
+	"context"
+	"database/sql"
 	"testing"
+	"time"
 
 	"fiatjaf.com/nostr"
 )
@@ -491,6 +494,92 @@ func TestEventStore_ReplaceEvent_OlderEvent(t *testing.T) {
 
 	if events[0].Content != "newer content" {
 		t.Errorf("ReplaceEvent() with older event kept wrong content = %q, want %q", events[0].Content, "newer content")
+	}
+}
+
+// TestEventStore_ReplaceEvent_SerializationRetry provokes a real PostgreSQL
+// serialization conflict by holding a SERIALIZABLE transaction open while
+// ReplaceEvent tries to touch the same rows. The first attempt should fail
+// with SQLSTATE 40001 and the retry should succeed.
+func TestEventStore_ReplaceEvent_SerializationRetry(t *testing.T) {
+	store := createTestEventStore()
+	store.Init()
+
+	secret := nostr.Generate()
+
+	// Seed an addressable event so ReplaceEvent has something to read.
+	event1 := nostr.Event{
+		Kind:      nostr.Kind(30023), // addressable kind
+		CreatedAt: nostr.Timestamp(1000000),
+		Content:   "original",
+		Tags:      nostr.Tags{{"d", "conflict-test"}},
+	}
+	event1.Sign(secret)
+	if err := store.ReplaceEvent(event1); err != nil {
+		t.Fatalf("seed ReplaceEvent: %v", err)
+	}
+
+	// Open a SERIALIZABLE transaction that reads the same row, creating a
+	// rw-dependency that will force the next ReplaceEvent to abort once we commit.
+	tx, err := GetDb().BeginTx(context.Background(), &sql.TxOptions{
+		Isolation: sql.LevelSerializable,
+	})
+	if err != nil {
+		t.Fatalf("begin blocking tx: %v", err)
+	}
+
+	// Read inside the blocking tx to establish the dependency.
+	eventsTable := store.Schema.Prefix("events")
+	row := tx.QueryRow("SELECT id FROM "+eventsTable+" WHERE kind = $1 LIMIT 1", int(event1.Kind))
+	var idStr string
+	if err := row.Scan(&idStr); err != nil {
+		tx.Rollback()
+		t.Fatalf("blocking tx read: %v", err)
+	}
+
+	// Write something in the blocking tx to create a real rw-conflict.
+	_, err = tx.Exec("UPDATE "+eventsTable+" SET content = 'blocked' WHERE id = $1", idStr)
+	if err != nil {
+		tx.Rollback()
+		t.Fatalf("blocking tx write: %v", err)
+	}
+
+	// Launch ReplaceEvent in a goroutine — it will block or conflict.
+	done := make(chan error, 1)
+	event2 := nostr.Event{
+		Kind:      nostr.Kind(30023),
+		CreatedAt: nostr.Timestamp(2000000),
+		Content:   "replacement",
+		Tags:      nostr.Tags{{"d", "conflict-test"}},
+	}
+	event2.Sign(secret)
+	go func() {
+		done <- store.ReplaceEvent(event2)
+	}()
+
+	// Give the goroutine a moment to start its transaction, then commit ours
+	// which forces PostgreSQL to abort the other.
+	time.Sleep(50 * time.Millisecond)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("blocking tx commit: %v", err)
+	}
+
+	// ReplaceEvent should succeed via retry.
+	if err := <-done; err != nil {
+		t.Fatalf("ReplaceEvent with contention should succeed via retry, got: %v", err)
+	}
+
+	// Verify the replacement landed.
+	filter := nostr.Filter{Kinds: []nostr.Kind{nostr.Kind(30023)}, Authors: []nostr.PubKey{secret.Public()}}
+	var results []nostr.Event
+	for evt := range store.QueryEvents(filter, 0) {
+		results = append(results, evt)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 event after retry, got %d", len(results))
+	}
+	if results[0].Content != "replacement" {
+		t.Errorf("content = %q, want %q", results[0].Content, "replacement")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `ReplaceEvent` uses `SERIALIZABLE` isolation but never retried on PostgreSQL's expected `40001` (serialization failure) errors
- Under concurrent group activity (joins, member count refreshes, list updates), these conflicts caused lost writes — breaking the announcements group in production (2026-03-29 through 2026-03-30)
- Extract transaction body into `replaceEventOnce`, wrap in retry loop (up to 3 attempts) on SQLSTATE `40001` only

## Test plan

- [ ] Existing `TestEventStore_ReplaceEvent` and `TestEventStore_ReplaceEvent_OlderEvent` still pass
- [ ] Full test suite passes
- [ ] Deploy and verify announcements group recovers on restart
- [ ] Monitor logs for `Serialization conflict replacing kind ...` — confirms retries are firing instead of silently failing

Fixes #11