### PR TITLE
CI: build Docker only on master, add Go test workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,10 +7,6 @@ on:
       - master
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
-      - master
   workflow_dispatch:
 
 env:
@@ -34,7 +30,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -48,7 +43,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-
@@ -59,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -67,7 +61,6 @@ jobs:
           platforms: linux/amd64
 
       - name: Generate artifact attestation
-        if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -75,7 +68,6 @@ jobs:
           push-to-registry: true
 
       - name: Output image digest
-        if: github.event_name != 'pull_request'
         run: |
           echo "Image pushed with tags:"
           echo "${{ steps.meta.outputs.tags }}"

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,42 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify formatting
+        run: |
+          unformatted=$(gofmt -l -s .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files need gofmt -s:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Run tests
+        env:
+          # Ryuk is the testcontainers reaper. The GHA runner is ephemeral
+          # and TestMain already calls Terminate(), so we don't need it,
+          # and disabling avoids a class of intermittent CI flakes.
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+        run: go test ./...

--- a/zooid/config.go
+++ b/zooid/config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-
 type Role struct {
 	Pubkeys   []string `toml:"pubkeys"`
 	CanInvite bool     `toml:"can_invite"`
@@ -34,7 +33,7 @@ type Config struct {
 	} `toml:"info"`
 
 	Policy struct {
-		Open            bool `toml:"open"`             // Allow all authenticated users (no membership required)
+		Open            bool `toml:"open"` // Allow all authenticated users (no membership required)
 		PublicJoin      bool `toml:"public_join"`
 		StripSignatures bool `toml:"strip_signatures"`
 	} `toml:"policy"`

--- a/zooid/metrics.go
+++ b/zooid/metrics.go
@@ -310,7 +310,7 @@ func collectDBMetrics(inst *Instance) {
 }
 
 var (
-	groupMessagesMu              sync.Mutex
+	groupMessagesMu             sync.Mutex
 	activeGroupMessageInstances = make(map[string]struct{})
 )
 

--- a/zooid/query_performance_test.go
+++ b/zooid/query_performance_test.go
@@ -488,4 +488,3 @@ func TestIntegration_QueryPerformance(t *testing.T) {
 		time.Sleep(dur)
 	}
 }
-


### PR DESCRIPTION
## Summary

- **Stop building Docker images on PRs.** The `pull_request` trigger in `docker-build.yml` ran the full multi-step build for every PR even though `push: ${{ github.event_name != 'pull_request' }}` already discarded the result, so the work was never useful. Removed the trigger, the now-dead `if: github.event_name != 'pull_request'` conditionals on the login/attestation/digest steps, and the `type=ref,event=pr` metadata tag. Master pushes, version tags, and `workflow_dispatch` still build and push as before.
- **Add a Go test workflow** that runs on master pushes and PRs (`.github/workflows/go-test.yml`). It uses `go-version-file: go.mod` so the runner version tracks the repo, runs a `gofmt -l -s` check, and executes `go test ./...`. `TESTCONTAINERS_RYUK_DISABLED=true` is set because `TestMain` already calls `pgContainer.Terminate(ctx)`, so the testcontainers reaper is unnecessary and disabling it avoids a known class of intermittent flakes on GHA runners.

## Test plan

- [x] `gofmt -l -s .` clean locally.
- [x] `go test ./...` passes locally (4–6s with the testcontainers Postgres).
- [ ] Workflow runs green on this PR (will be visible once the workflow lands on master and the trigger fires).