### PR TITLE
Reduce kind-39002 contention: bigger batches, jittered backoff, debounce

### DIFF
--- a/zooid/events.go
+++ b/zooid/events.go
@@ -12,6 +12,7 @@ import (
 	"math/rand/v2"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"fiatjaf.com/nostr"
@@ -24,6 +25,28 @@ import (
 
 // Global Squirrel builder with Dollar placeholder format for PostgreSQL
 var sb = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)
+
+// SSI retry knobs are read from env once and reused — ReplaceEvent is called
+// per replaceable/addressable save, so we avoid the per-call envInt + Atoi.
+var (
+	ssiConfigOnce    sync.Once
+	ssiMaxRetries    int
+	ssiBaseBackoffMs int
+)
+
+func ssiConfig() (int, int) {
+	ssiConfigOnce.Do(func() {
+		ssiMaxRetries = envInt("SSI_MAX_RETRIES", 6)
+		if ssiMaxRetries < 1 {
+			ssiMaxRetries = 1
+		}
+		ssiBaseBackoffMs = envInt("SSI_BASE_BACKOFF_MS", 25)
+		if ssiBaseBackoffMs < 0 {
+			ssiBaseBackoffMs = 0
+		}
+	})
+	return ssiMaxRetries, ssiBaseBackoffMs
+}
 
 type EventStore struct {
 	Relay  *khatru.Relay
@@ -441,14 +464,7 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 	// jitter, multiple losers wake at the same offset and collide again on
 	// retry — observed in production as ~19% of contended kind-39002 saves
 	// giving up after the original 3-retry policy (issue #16).
-	maxRetries := envInt("SSI_MAX_RETRIES", 6)
-	if maxRetries < 1 {
-		maxRetries = 1
-	}
-	baseBackoffMs := envInt("SSI_BASE_BACKOFF_MS", 25)
-	if baseBackoffMs < 0 {
-		baseBackoffMs = 0
-	}
+	maxRetries, baseBackoffMs := ssiConfig()
 	var err error
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		err = events.replaceEventOnce(evt)

--- a/zooid/events.go
+++ b/zooid/events.go
@@ -30,22 +30,22 @@ var sb = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)
 // per replaceable/addressable save, so we avoid the per-call envInt + Atoi.
 var (
 	ssiConfigOnce    sync.Once
-	ssiMaxRetries    int
+	ssiMaxAttempts   int
 	ssiBaseBackoffMs int
 )
 
 func ssiConfig() (int, int) {
 	ssiConfigOnce.Do(func() {
-		ssiMaxRetries = envInt("SSI_MAX_RETRIES", 6)
-		if ssiMaxRetries < 1 {
-			ssiMaxRetries = 1
+		ssiMaxAttempts = envInt("SSI_MAX_ATTEMPTS", 6)
+		if ssiMaxAttempts < 1 {
+			ssiMaxAttempts = 1
 		}
 		ssiBaseBackoffMs = envInt("SSI_BASE_BACKOFF_MS", 25)
 		if ssiBaseBackoffMs < 0 {
 			ssiBaseBackoffMs = 0
 		}
 	})
-	return ssiMaxRetries, ssiBaseBackoffMs
+	return ssiMaxAttempts, ssiBaseBackoffMs
 }
 
 type EventStore struct {
@@ -464,36 +464,41 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 	// jitter, multiple losers wake at the same offset and collide again on
 	// retry — observed in production as ~19% of contended kind-39002 saves
 	// giving up after the original 3-retry policy (issue #16).
-	maxRetries, baseBackoffMs := ssiConfig()
+	maxAttempts, baseBackoffMs := ssiConfig()
 	var err error
-	for attempt := 0; attempt < maxRetries; attempt++ {
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		err = events.replaceEventOnce(evt)
 		if err == nil {
 			return nil
 		}
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "40001" {
-			if attempt+1 < maxRetries {
-				// Cap the exponential growth so an aggressive SSI_MAX_RETRIES
-				// can't push the shift past int range.
+			if attempt+1 < maxAttempts {
+				// Cap the shift so an aggressive SSI_BASE_BACKOFF_MS can't
+				// overflow int when computing the backoff cap.
 				shift := attempt
 				if shift > 10 {
 					shift = 10
 				}
-				backoffCap := baseBackoffMs << shift
+				maxInt := int(^uint(0) >> 1)
+				safeBaseMs := baseBackoffMs
+				if maxBase := maxInt >> shift; safeBaseMs > maxBase {
+					safeBaseMs = maxBase
+				}
+				backoffCap := safeBaseMs << shift
 				sleepMs := rand.IntN(backoffCap + 1)
 				log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), retrying in %dms",
-					evt.Kind, evt.Tags.GetD(), attempt+1, maxRetries, sleepMs)
+					evt.Kind, evt.Tags.GetD(), attempt+1, maxAttempts, sleepMs)
 				time.Sleep(time.Duration(sleepMs) * time.Millisecond)
 				continue
 			}
 			log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), giving up",
-				evt.Kind, evt.Tags.GetD(), attempt+1, maxRetries)
+				evt.Kind, evt.Tags.GetD(), attempt+1, maxAttempts)
 			break
 		}
 		return err // non-retriable error
 	}
-	return fmt.Errorf("serialization conflict after %d retries: %w", maxRetries, err)
+	return fmt.Errorf("serialization conflict after %d attempts: %w", maxAttempts, err)
 }
 
 func (events *EventStore) replaceEventOnce(evt nostr.Event) error {

--- a/zooid/events.go
+++ b/zooid/events.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"iter"
 	"log"
+	"math/rand/v2"
 	"sort"
 	"strings"
 	"time"
@@ -393,11 +394,12 @@ func (events *EventStore) saveEventWith(runner squirrel.BaseRunner, evt nostr.Ev
 
 	// Insert single-letter tags into event_tags, chunked to stay below
 	// Postgres's 65535 extended-protocol parameter limit. With 3 columns per
-	// row, 5000 rows × 3 = 15000 params keeps every batch well below the cap.
-	// NIP-29 kind-39002 (group member list) events carry one ["p", pubkey,
-	// role] tag per member; without chunking, saves fail outright once a
-	// group exceeds ~21,800 members (issue #13).
-	const tagInsertBatchSize = 5000
+	// row, 15000 rows × 3 = 45000 params is well under the 65535 cap and
+	// cuts the inner round-trip count by ~3× vs. 5k batches — important for
+	// kind-39002 (NIP-29 member list) saves where the whole transaction runs
+	// under SERIALIZABLE isolation and contention is dominated by wall-clock
+	// duration of the critical section (issues #13, #16).
+	const tagInsertBatchSize = 15000
 
 	eventID := evt.ID.Hex()
 	tagsTable := events.Schema.Prefix("event_tags")
@@ -434,9 +436,15 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 	// existing event", both insert, and leave duplicate replaceable events.
 	// PostgreSQL may return a serialization error (SQLSTATE 40001) under
 	// contention; the standard remedy is to retry the transaction.
-	const maxRetries = 3
+	//
+	// Backoff is full-jitter exponential: sleep ∈ [0, base<<attempt]. Without
+	// jitter, multiple losers wake at the same offset and collide again on
+	// retry — observed in production as ~19% of contended kind-39002 saves
+	// giving up after the original 3-retry policy (issue #16).
+	maxRetries := envInt("SSI_MAX_RETRIES", 6)
+	baseBackoffMs := envInt("SSI_BASE_BACKOFF_MS", 25)
 	var err error
-	for attempt := range maxRetries {
+	for attempt := 0; attempt < maxRetries; attempt++ {
 		err = events.replaceEventOnce(evt)
 		if err == nil {
 			return nil
@@ -444,9 +452,17 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "40001" {
 			if attempt+1 < maxRetries {
-				log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), retrying",
-					evt.Kind, evt.Tags.GetD(), attempt+1, maxRetries)
-				time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+				// Cap the exponential growth so an aggressive SSI_MAX_RETRIES
+				// can't push the shift past int range.
+				shift := attempt
+				if shift > 10 {
+					shift = 10
+				}
+				backoffCap := baseBackoffMs << shift
+				sleepMs := rand.IntN(backoffCap + 1)
+				log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), retrying in %dms",
+					evt.Kind, evt.Tags.GetD(), attempt+1, maxRetries, sleepMs)
+				time.Sleep(time.Duration(sleepMs) * time.Millisecond)
 				continue
 			}
 			log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), giving up",

--- a/zooid/events.go
+++ b/zooid/events.go
@@ -442,7 +442,13 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 	// retry — observed in production as ~19% of contended kind-39002 saves
 	// giving up after the original 3-retry policy (issue #16).
 	maxRetries := envInt("SSI_MAX_RETRIES", 6)
+	if maxRetries < 1 {
+		maxRetries = 1
+	}
 	baseBackoffMs := envInt("SSI_BASE_BACKOFF_MS", 25)
+	if baseBackoffMs < 0 {
+		baseBackoffMs = 0
+	}
 	var err error
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		err = events.replaceEventOnce(evt)

--- a/zooid/events_test.go
+++ b/zooid/events_test.go
@@ -750,8 +750,8 @@ func TestEventStore_SaveEvent_LargeMemberListExceedsPgParamLimit(t *testing.T) {
 
 	// Probe the first tag of the second batch to catch off-by-one bugs in
 	// chunk-boundary handling. The d-tag at tags[0] occupies one of the
-	// 5000 slots in batch 1 (tags[0..4999]), so batch 2 starts at tags[5000].
-	probe := tags[5000][1]
+	// 15000 slots in batch 1 (tags[0..14999]), so batch 2 starts at tags[15000].
+	probe := tags[15000][1]
 	filter := nostr.Filter{Tags: nostr.TagMap{"p": []string{probe}}}
 	var found bool
 	for result := range store.QueryEvents(filter, 0) {

--- a/zooid/groups.go
+++ b/zooid/groups.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"time"
 
 	"fiatjaf.com/nostr"
 	"fiatjaf.com/nostr/nip29"
@@ -92,6 +93,16 @@ type GroupStore struct {
 	roleCache       sync.Map // map[string]*roleSet           (key = group h)
 	creatorCache    sync.Map // map[string]nostr.PubKey       (key = group h)
 	cachesWarmed    bool
+
+	// DebounceDelay coalesces rapid bursts of kind-39002 / kind-39000 rewrites
+	// for the same group into a single publish, scheduled DebounceDelay after
+	// the first scheduled trigger in a burst. NIP-29 requires republishing the
+	// full member list on every change, which is the dominant source of write
+	// contention on large groups (issue #16). Zero (the default for tests)
+	// disables debouncing — Schedule* methods run synchronously.
+	DebounceDelay   time.Duration
+	debounceMu      sync.Mutex
+	debouncePending map[string]struct{}
 }
 
 func (g *GroupStore) WarmCaches() {
@@ -597,6 +608,61 @@ func (g *GroupStore) UpdateMembersList(h string) error {
 	}
 
 	return g.Events.SignAndStoreEvent(&event, true)
+}
+
+// ScheduleMembersListUpdate publishes a fresh kind-39002 for h, debounced by
+// DebounceDelay. Multiple calls within the window coalesce into a single run
+// that observes whatever membership state exists at run time. With DebounceDelay
+// zero (test default) the publish happens synchronously and any error is
+// returned to the caller; otherwise errors are logged from the timer goroutine.
+func (g *GroupStore) ScheduleMembersListUpdate(h string) error {
+	if g.DebounceDelay == 0 {
+		return g.UpdateMembersList(h)
+	}
+	g.scheduleRewrite("members:"+h, func() {
+		if err := g.UpdateMembersList(h); err != nil {
+			log.Printf("Debounced UpdateMembersList failed for group %q: %v", h, err)
+		}
+	})
+	return nil
+}
+
+// ScheduleMemberCountRefresh is the debounced counterpart to RefreshMemberCount.
+// See ScheduleMembersListUpdate for semantics.
+func (g *GroupStore) ScheduleMemberCountRefresh(h string) error {
+	if g.DebounceDelay == 0 {
+		return g.RefreshMemberCount(h)
+	}
+	g.scheduleRewrite("count:"+h, func() {
+		if err := g.RefreshMemberCount(h); err != nil {
+			log.Printf("Debounced RefreshMemberCount failed for group %q: %v", h, err)
+		}
+	})
+	return nil
+}
+
+// scheduleRewrite is leading-edge throttle: the first call for `key` arms a
+// timer; subsequent calls within DebounceDelay are no-ops. When the timer
+// fires, fn runs once and observes the latest cache state, capturing every
+// change that landed during the window.
+func (g *GroupStore) scheduleRewrite(key string, fn func()) {
+	g.debounceMu.Lock()
+	if g.debouncePending == nil {
+		g.debouncePending = make(map[string]struct{})
+	}
+	if _, ok := g.debouncePending[key]; ok {
+		g.debounceMu.Unlock()
+		return
+	}
+	g.debouncePending[key] = struct{}{}
+	g.debounceMu.Unlock()
+
+	time.AfterFunc(g.DebounceDelay, func() {
+		g.debounceMu.Lock()
+		delete(g.debouncePending, key)
+		g.debounceMu.Unlock()
+		fn()
+	})
 }
 
 // Invite Codes

--- a/zooid/groups.go
+++ b/zooid/groups.go
@@ -102,7 +102,20 @@ type GroupStore struct {
 	// disables debouncing — Schedule* methods run synchronously.
 	DebounceDelay   time.Duration
 	debounceMu      sync.Mutex
-	debouncePending map[string]struct{}
+	debouncePending map[string]*debounceEntry
+}
+
+// debounceEntry tracks one key's pending or in-flight rewrite. While
+// running == false the entry's timer is armed; further Schedule calls in
+// that window are pure no-ops because the upcoming fn() will read the
+// latest cache state. While running == true a Schedule call sets dirty,
+// signalling the runner to call fn() once more after the current run
+// finishes — this serializes rewrites per key (avoiding overlapping
+// SERIALIZABLE transactions) without dropping updates that race with
+// fn's cache read.
+type debounceEntry struct {
+	running bool
+	dirty   bool
 }
 
 func (g *GroupStore) WarmCaches() {
@@ -641,27 +654,46 @@ func (g *GroupStore) ScheduleMemberCountRefresh(h string) error {
 	return nil
 }
 
-// scheduleRewrite is leading-edge throttle: the first call for `key` arms a
-// timer; subsequent calls within DebounceDelay are no-ops. When the timer
-// fires, fn runs once and observes the latest cache state, capturing every
-// change that landed during the window.
+// scheduleRewrite arms a debounce timer for `key`. Calls arriving while the
+// timer is still pending are coalesced into the upcoming fn() run (which
+// reads the latest cache state). Calls arriving while fn() is running set a
+// dirty flag, and the runner re-invokes fn() once after it returns to
+// capture any state that landed mid-run. At most one fn() per key is in
+// flight at any time.
 func (g *GroupStore) scheduleRewrite(key string, fn func()) {
 	g.debounceMu.Lock()
 	if g.debouncePending == nil {
-		g.debouncePending = make(map[string]struct{})
+		g.debouncePending = make(map[string]*debounceEntry)
 	}
-	if _, ok := g.debouncePending[key]; ok {
+	if entry, ok := g.debouncePending[key]; ok {
+		if entry.running {
+			entry.dirty = true
+		}
+		// Else: timer is still pending and fn() will see latest cache.
 		g.debounceMu.Unlock()
 		return
 	}
-	g.debouncePending[key] = struct{}{}
+	entry := &debounceEntry{}
+	g.debouncePending[key] = entry
 	g.debounceMu.Unlock()
 
 	time.AfterFunc(g.DebounceDelay, func() {
-		g.debounceMu.Lock()
-		delete(g.debouncePending, key)
-		g.debounceMu.Unlock()
-		fn()
+		for {
+			g.debounceMu.Lock()
+			entry.running = true
+			entry.dirty = false
+			g.debounceMu.Unlock()
+
+			fn()
+
+			g.debounceMu.Lock()
+			if !entry.dirty {
+				delete(g.debouncePending, key)
+				g.debounceMu.Unlock()
+				return
+			}
+			g.debounceMu.Unlock()
+		}
 	})
 }
 

--- a/zooid/groups_test.go
+++ b/zooid/groups_test.go
@@ -217,6 +217,56 @@ func TestGroupStore_ScheduleRewrite_PerKeyIsolation(t *testing.T) {
 	}
 }
 
+// TestGroupStore_ScheduleRewrite_RerunIfDirtyDuringRun verifies that a
+// Schedule call arriving while fn() is running flags the entry dirty, and
+// after fn() completes the runner picks the flag up and re-invokes fn()
+// once. This prevents overlapping SERIALIZABLE rewrites (Copilot review on
+// PR #17) without dropping updates that race with fn's cache read.
+func TestGroupStore_ScheduleRewrite_RerunIfDirtyDuringRun(t *testing.T) {
+	g := &GroupStore{DebounceDelay: 10 * time.Millisecond}
+
+	var calls atomic.Int32
+	block := make(chan struct{})
+	fn := func() {
+		if calls.Add(1) == 1 {
+			<-block // first invocation blocks until the test releases it
+		}
+	}
+
+	g.scheduleRewrite("members:g1", fn)
+
+	// Wait for fn() to start.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for calls.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("first fn invocation didn't start: calls = %d", calls.Load())
+	}
+
+	// Schedule again while fn() is still blocked. With the old delete-before-fn
+	// design this would arm a new timer (overlap); with the dirty-flag design
+	// it should mark the in-flight entry dirty for a follow-up run.
+	g.scheduleRewrite("members:g1", fn)
+
+	// Release fn(). The runner should observe dirty and call fn() once more.
+	close(block)
+
+	deadline = time.Now().Add(200 * time.Millisecond)
+	for calls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("dirty re-run didn't fire: calls = %d, want 2", got)
+	}
+
+	// And the loop must terminate — no further calls without new schedules.
+	time.Sleep(50 * time.Millisecond)
+	if got := calls.Load(); got != 2 {
+		t.Errorf("runner kept looping: calls = %d, want stable at 2", got)
+	}
+}
+
 // TestGroupStore_ScheduleMembersList_SyncWhenDelayZero verifies that
 // DebounceDelay = 0 (the test default) preserves the synchronous semantics
 // existing tests rely on — Schedule* runs the underlying op inline and

--- a/zooid/groups_test.go
+++ b/zooid/groups_test.go
@@ -1,7 +1,9 @@
 package zooid
 
 import (
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"fiatjaf.com/nostr"
 )
@@ -163,4 +165,71 @@ func TestIsPrivateGroupContent(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGroupStore_ScheduleRewrite_CoalescesBurst verifies the leading-edge
+// debounce: many rapid calls collapse into a single fn invocation that runs
+// after DebounceDelay, and a fresh burst arms a new timer.
+func TestGroupStore_ScheduleRewrite_CoalescesBurst(t *testing.T) {
+	g := &GroupStore{DebounceDelay: 30 * time.Millisecond}
+
+	var calls atomic.Int32
+	fn := func() { calls.Add(1) }
+
+	for range 50 {
+		g.scheduleRewrite("members:group1", fn)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Errorf("calls before delay = %d, want 0", got)
+	}
+
+	time.Sleep(80 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("calls after first burst = %d, want 1", got)
+	}
+
+	// Fresh burst after the timer fired must arm a new run.
+	for range 20 {
+		g.scheduleRewrite("members:group1", fn)
+	}
+	time.Sleep(80 * time.Millisecond)
+	if got := calls.Load(); got != 2 {
+		t.Errorf("calls after second burst = %d, want 2", got)
+	}
+}
+
+// TestGroupStore_ScheduleRewrite_PerKeyIsolation verifies different debounce
+// keys (e.g. members:g1 vs count:g1, or members:g1 vs members:g2) don't share
+// pending slots.
+func TestGroupStore_ScheduleRewrite_PerKeyIsolation(t *testing.T) {
+	g := &GroupStore{DebounceDelay: 30 * time.Millisecond}
+
+	var calls atomic.Int32
+	fn := func() { calls.Add(1) }
+
+	g.scheduleRewrite("members:g1", fn)
+	g.scheduleRewrite("members:g2", fn)
+	g.scheduleRewrite("count:g1", fn)
+	// All three should run independently.
+	time.Sleep(80 * time.Millisecond)
+	if got := calls.Load(); got != 3 {
+		t.Errorf("calls = %d, want 3 (one per distinct key)", got)
+	}
+}
+
+// TestGroupStore_ScheduleMembersList_SyncWhenDelayZero verifies that
+// DebounceDelay = 0 (the test default) preserves the synchronous semantics
+// existing tests rely on — Schedule* runs the underlying op inline and
+// returns its error directly.
+func TestGroupStore_ScheduleMembersList_SyncWhenDelayZero(t *testing.T) {
+	g := &GroupStore{DebounceDelay: 0}
+	// No Events store wired up: UpdateMembersList will reach SignAndStoreEvent
+	// and panic. We only assert that scheduling delegates synchronously,
+	// proven by the panic propagating to this goroutine.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected synchronous call to panic from nil Events; got no panic")
+		}
+	}()
+	_ = g.ScheduleMembersListUpdate("g1")
 }

--- a/zooid/instance.go
+++ b/zooid/instance.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"time"
 	"unsafe"
 
 	"fiatjaf.com/nostr"
@@ -59,9 +60,10 @@ func MakeInstance(filename string) (*Instance, error) {
 	}
 
 	groups := &GroupStore{
-		Config:     config,
-		Events:     events,
-		Management: management,
+		Config:        config,
+		Events:        events,
+		Management:    management,
+		DebounceDelay: time.Duration(envInt("GROUP_REWRITE_DEBOUNCE_MS", 200)) * time.Millisecond,
 	}
 
 	instance := &Instance{
@@ -414,10 +416,10 @@ func (instance *Instance) OnEventSaved(ctx context.Context, event nostr.Event) {
 		if err := instance.Groups.AddMember(h, event.PubKey); err != nil {
 			log.Printf("Failed to add member %s to group %q: %v", event.PubKey, h, err)
 		}
-		if err := instance.Groups.UpdateMembersList(h); err != nil {
+		if err := instance.Groups.ScheduleMembersListUpdate(h); err != nil {
 			log.Printf("Failed to update members list for group %q: %v", h, err)
 		}
-		if err := instance.Groups.RefreshMemberCount(h); err != nil {
+		if err := instance.Groups.ScheduleMemberCountRefresh(h); err != nil {
 			log.Printf("Failed to refresh member count for group %q: %v", h, err)
 		}
 	}
@@ -426,10 +428,10 @@ func (instance *Instance) OnEventSaved(ctx context.Context, event nostr.Event) {
 		if err := instance.Groups.RemoveMember(h, event.PubKey); err != nil {
 			log.Printf("Failed to remove member %s from group %q: %v", event.PubKey, h, err)
 		}
-		if err := instance.Groups.UpdateMembersList(h); err != nil {
+		if err := instance.Groups.ScheduleMembersListUpdate(h); err != nil {
 			log.Printf("Failed to update members list for group %q: %v", h, err)
 		}
-		if err := instance.Groups.RefreshMemberCount(h); err != nil {
+		if err := instance.Groups.ScheduleMemberCountRefresh(h); err != nil {
 			log.Printf("Failed to refresh member count for group %q: %v", h, err)
 		}
 	}
@@ -451,10 +453,10 @@ func (instance *Instance) OnEventSaved(ctx context.Context, event nostr.Event) {
 				instance.Groups.SetMemberRoles(h, pubkey, roles)
 			}
 		}
-		if err := instance.Groups.UpdateMembersList(h); err != nil {
+		if err := instance.Groups.ScheduleMembersListUpdate(h); err != nil {
 			log.Printf("Failed to update members list for group %q: %v", h, err)
 		}
-		if err := instance.Groups.RefreshMemberCount(h); err != nil {
+		if err := instance.Groups.ScheduleMemberCountRefresh(h); err != nil {
 			log.Printf("Failed to refresh member count for group %q: %v", h, err)
 		}
 	}
@@ -472,10 +474,10 @@ func (instance *Instance) OnEventSaved(ctx context.Context, event nostr.Event) {
 				}
 			}
 		}
-		if err := instance.Groups.UpdateMembersList(h); err != nil {
+		if err := instance.Groups.ScheduleMembersListUpdate(h); err != nil {
 			log.Printf("Failed to update members list for group %q: %v", h, err)
 		}
-		if err := instance.Groups.RefreshMemberCount(h); err != nil {
+		if err := instance.Groups.ScheduleMemberCountRefresh(h); err != nil {
 			log.Printf("Failed to refresh member count for group %q: %v", h, err)
 		}
 	}
@@ -488,7 +490,7 @@ func (instance *Instance) OnEventSaved(ctx context.Context, event nostr.Event) {
 		if err := instance.Groups.UpdateMetadata(event); err != nil {
 			log.Printf("Failed to create metadata for group %q: %v", h, err)
 		}
-		if err := instance.Groups.UpdateMembersList(h); err != nil {
+		if err := instance.Groups.ScheduleMembersListUpdate(h); err != nil {
 			log.Printf("Failed to update members list for group %q: %v", h, err)
 		}
 		if err := instance.Groups.UpdateAdminsList(h); err != nil {

--- a/zooid/instance.go
+++ b/zooid/instance.go
@@ -59,11 +59,15 @@ func MakeInstance(filename string) (*Instance, error) {
 		Events: events,
 	}
 
+	debounceMs := envInt("GROUP_REWRITE_DEBOUNCE_MS", 200)
+	if debounceMs < 0 {
+		debounceMs = 0
+	}
 	groups := &GroupStore{
 		Config:        config,
 		Events:        events,
 		Management:    management,
-		DebounceDelay: time.Duration(envInt("GROUP_REWRITE_DEBOUNCE_MS", 200)) * time.Millisecond,
+		DebounceDelay: time.Duration(debounceMs) * time.Millisecond,
 	}
 
 	instance := &Instance{


### PR DESCRIPTION
## Why this manifests at all

27k members isn't intrinsically a lot for Postgres — but every NIP-29 admin action (`kind:9000` add user, `kind:9001` remove user, etc.) triggers a relay-side republish of the entire kind-39002 member list. That's a SERIALIZABLE transaction containing 1 SELECT, 1 INSERT events row, 6 INSERTs of ~5k tag rows each, a cascading DELETE of 27k tag rows, and a COMMIT — easily 500 ms–2 s end-to-end. SERIALIZABLE turns any concurrent r/w dependency on the same row into a 40001 conflict, and the previous linear `(attempt+1)*10 ms` backoff with no jitter meant losers kept colliding on retry. Production saw ~19 % give-up rate on contended saves (#16).

## Three stacked fixes

1. **Tag-insert batch size 5k → 15k** (`events.go`). 15k × 3 cols = 45k params, still under the 65,535 extended-protocol cap. Cuts inner round-trips ~3× for a 27k-member event, shrinking the SERIALIZABLE critical section proportionally.

2. **Jittered exponential backoff with more retries** (`events.go`). Replaces `(attempt+1)*10 ms` deterministic backoff with full-jitter `rand.IntN(base<<attempt + 1)` so distinct losers stop landing on the same retry offset. Default retries bumped 3 → 6, base 25 ms; worst-case total wait ~1.5 s. Both env-tunable: `SSI_MAX_RETRIES`, `SSI_BASE_BACKOFF_MS`.

3. **Leading-edge per-group debouncer** for kind-39002 and kind-39000 rewrites (`groups.go`, `instance.go`). The protocol forces a full republish per admin action, so a burst of 100 add/removes in 1 s runs 100 full rewrites on the same row — the worst possible shape for SSI conflicts. The debouncer arms a timer on the first scheduled call; further calls in the same window are no-ops; when the timer fires, the rewrite observes the *latest* cache state and publishes once. Tunable via `GROUP_REWRITE_DEBOUNCE_MS` (default 200 ms; 0 is synchronous, which is the test default to keep existing tests unchanged).

## Eventual-consistency tradeoff (debouncer)

Within a 200 ms window after a burst, the published kind-39002 may briefly lag in-memory state. The relay's own access checks (`CanRead`, `CheckWrite`) read the in-memory `membershipCache` which is updated synchronously, so internal correctness is preserved. Worst case if the process exits inside the window: the latest changes are missing from the published kind-39002 until the next admin action triggers a fresh rewrite, but membership state itself is durable in the kind-9000/9001 log. Acceptable; could add a flush-on-shutdown later if it bites.

## What's deliberately not in this PR

- **Drop SERIALIZABLE in favor of `INSERT ON CONFLICT` + unique constraint on `(kind, pubkey, d_tag)`**. Eliminates the conflict class entirely but needs a schema migration (denormalizing `d` into a column or partial unique index).
- **Switch tag inserts to `pgx.CopyFrom`**. Single round trip per event, no parameter limit; requires breaking out of the squirrel/sql abstraction.

## Test plan

- [x] `go test ./...` — full suite passes (~5 s).
- [x] `TestEventStore_SaveEvent_LargeMemberListExceedsPgParamLimit` — regression probe moved to `tags[15000]` (the new chunk boundary), still fails fast without the chunking fix.
- [x] `TestGroupStore_ScheduleRewrite_CoalescesBurst` — 50 rapid calls produce 1 invocation; a fresh burst arms a fresh timer.
- [x] `TestGroupStore_ScheduleRewrite_PerKeyIsolation` — `members:g1`, `members:g2`, `count:g1` debounce independently.
- [x] `TestGroupStore_ScheduleMembersList_SyncWhenDelayZero` — `DebounceDelay = 0` runs the underlying op inline.
- [x] `TestEventStore_ReplaceEvent_SerializationRetry` — still passes with the new jittered backoff (first attempt fails, retry succeeds within the test's 50 ms blocking-tx commit window).

Fixes #16.