### PR TITLE
Bound DB tx wall-clock time and add pprof to fix goroutine leak (#18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ Groups have three independent flags set via metadata tags: `private` (content re
 
 `DATABASE_URL` (required, PostgreSQL connection string), `PORT` (default 3334), `CONFIG` (default ./config), `MEDIA` (default ./media). See `env.go` and `database.go`.
 
+`PPROF_ADDR` (optional, e.g. `127.0.0.1:6060`) enables `net/http/pprof` on a separate listener. Bind to localhost and reach it via SSH/port-forward — never expose pprof publicly.
+
 ### Config Policy Options
 
 - `policy.open` — allows all authenticated users without relay membership

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Zooid supports a few environment variables, which configure shared resources lik
 - `DB_MAX_OPEN_CONNS` - maximum open database connections. Defaults to `20`.
 - `DB_MAX_IDLE_CONNS` - maximum idle database connections. Defaults to `5`.
 - `DB_CONN_MAX_LIFETIME_SECS` - connection max lifetime in seconds. Defaults to `300`.
+- `PPROF_ADDR` - if set (e.g. `127.0.0.1:6060`), serves `net/http/pprof` on a separate listener. **Bind to localhost** and reach it via SSH/port-forward — never expose pprof publicly.
 
 ## Configuration
 
@@ -407,3 +408,4 @@ When running in AWS ECS, these environment variables configure the relay:
 | `DB_MAX_OPEN_CONNS` | Max open DB connections (default: `20`) |
 | `DB_MAX_IDLE_CONNS` | Max idle DB connections (default: `5`) |
 | `DB_CONN_MAX_LIFETIME_SECS` | Connection max lifetime in seconds (default: `300`) |
+| `PPROF_ADDR` | If set (e.g. `127.0.0.1:6060`), serves `net/http/pprof` on a separate listener. Bind to localhost only — never expose publicly. |

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -14,6 +15,34 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+// pprofAddrIsLoopback rejects PPROF_ADDR values that would expose pprof on a
+// public interface. Documentation says "bind to localhost"; this enforces it
+// at startup so a stray PPROF_ADDR=":6060" doesn't leak heap/goroutine dumps.
+// Returns (ok, reason) — reason is empty when ok is true.
+func pprofAddrIsLoopback(addr string) (bool, string) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false, fmt.Sprintf("invalid host:port: %v", err)
+	}
+	if host == "" {
+		// ":6060" with no host listens on all interfaces.
+		return false, "host is empty (binds all interfaces); use 127.0.0.1 or [::1]"
+	}
+	if host == "localhost" {
+		return true, ""
+	}
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return false, fmt.Sprintf("could not resolve host %q: %v", host, err)
+	}
+	for _, ip := range ips {
+		if !ip.IsLoopback() {
+			return false, fmt.Sprintf("host %q resolves to non-loopback %s", host, ip)
+		}
+	}
+	return true, ""
+}
 
 func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
@@ -54,6 +83,9 @@ func main() {
 	// must not be reachable from the public internet (issue #18 needed
 	// `goroutine?debug=2` from a leaking task to localize the leak).
 	if pprofAddr := os.Getenv("PPROF_ADDR"); pprofAddr != "" {
+		if ok, reason := pprofAddrIsLoopback(pprofAddr); !ok {
+			log.Fatalf("refusing to start pprof on %q: %s — pprof must bind to a loopback address; use SSH/port-forward to access it remotely", pprofAddr, reason)
+		}
 		go func() {
 			log.Printf("pprof server listening on %s\n", pprofAddr)
 			if err := http.ListenAndServe(pprofAddr, nil); err != nil {

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
@@ -47,6 +48,19 @@ func main() {
 			log.Printf("HTTP server error: %v\n", err)
 		}
 	}()
+
+	// Optional pprof server on a separate port. Bind it to localhost only and
+	// expose via SSH/port-forward in production — the runtime/debug endpoints
+	// must not be reachable from the public internet (issue #18 needed
+	// `goroutine?debug=2` from a leaking task to localize the leak).
+	if pprofAddr := os.Getenv("PPROF_ADDR"); pprofAddr != "" {
+		go func() {
+			log.Printf("pprof server listening on %s\n", pprofAddr)
+			if err := http.ListenAndServe(pprofAddr, nil); err != nil {
+				log.Printf("pprof server error: %v\n", err)
+			}
+		}()
+	}
 
 	go zooid.Start()
 	zooid.StartMetricsCollector()

--- a/cmd/relay/main_test.go
+++ b/cmd/relay/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestPprofAddrIsLoopback(t *testing.T) {
+	cases := []struct {
+		addr   string
+		wantOK bool
+	}{
+		{"127.0.0.1:6060", true},
+		{"[::1]:6060", true},
+		{"localhost:6060", true},
+
+		{":6060", false},        // empty host = all interfaces
+		{"0.0.0.0:6060", false}, // any IPv4
+		{"[::]:6060", false},    // any IPv6
+		{"8.8.8.8:6060", false}, // arbitrary public IP
+		{"6060", false},         // missing colon = invalid host:port
+		{"", false},             // empty
+	}
+	for _, c := range cases {
+		t.Run(c.addr, func(t *testing.T) {
+			got, reason := pprofAddrIsLoopback(c.addr)
+			if got != c.wantOK {
+				t.Errorf("pprofAddrIsLoopback(%q) = %v (%s), want %v", c.addr, got, reason, c.wantOK)
+			}
+			if !got && reason == "" {
+				t.Errorf("pprofAddrIsLoopback(%q) returned ok=false but no reason", c.addr)
+			}
+		})
+	}
+}

--- a/zooid/events.go
+++ b/zooid/events.go
@@ -48,6 +48,22 @@ func ssiConfig() (int, int) {
 	return ssiMaxAttempts, ssiBaseBackoffMs
 }
 
+// Per-call wall-clock budgets for DB transactions. Without a deadline,
+// BeginTx parks the calling goroutine indefinitely on the database/sql pool's
+// (unbounded) wait channel when the pool is saturated — that's the goroutine
+// leak observed in issue #18 after PR #17, where 15k-tag SERIALIZABLE saves
+// hold pool connections for ~2s and 6 jittered retries push individual
+// ReplaceEvent calls to ~13s, easily exhausting the default 20-conn pool.
+//
+// With these bounds, a contended caller fails fast instead of accumulating.
+// The defaults are chosen to be ~3× the legitimate worst case so normal load
+// doesn't see them. They're var (not const) so the regression test in
+// events_test.go can shrink them to keep the test fast.
+var (
+	saveEventTxTimeout      = 30 * time.Second
+	replaceEventTotalBudget = 60 * time.Second
+)
+
 type EventStore struct {
 	Relay  *khatru.Relay
 	Config *Config
@@ -369,7 +385,10 @@ func (events *EventStore) deleteEventWith(runner squirrel.BaseRunner, id nostr.I
 }
 
 func (events *EventStore) SaveEvent(evt nostr.Event) error {
-	tx, err := GetDb().Begin()
+	ctx, cancel := context.WithTimeout(context.Background(), saveEventTxTimeout)
+	defer cancel()
+
+	tx, err := GetDb().BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
@@ -464,10 +483,19 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 	// jitter, multiple losers wake at the same offset and collide again on
 	// retry — observed in production as ~19% of contended kind-39002 saves
 	// giving up after the original 3-retry policy (issue #16).
+	//
+	// The whole retry loop runs under a single deadline so a caller can't park
+	// indefinitely on the pool wait queue when the pool is saturated (#18).
+	ctx, cancel := context.WithTimeout(context.Background(), replaceEventTotalBudget)
+	defer cancel()
+
 	maxAttempts, baseBackoffMs := ssiConfig()
 	var err error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		err = events.replaceEventOnce(evt)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("replace event budget exceeded after %d attempts: %w", attempt, ctxErr)
+		}
+		err = events.replaceEventOnce(ctx, evt)
 		if err == nil {
 			return nil
 		}
@@ -489,7 +517,13 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 				sleepMs := rand.IntN(backoffCap + 1)
 				log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), retrying in %dms",
 					evt.Kind, evt.Tags.GetD(), attempt+1, maxAttempts, sleepMs)
-				time.Sleep(time.Duration(sleepMs) * time.Millisecond)
+				timer := time.NewTimer(time.Duration(sleepMs) * time.Millisecond)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return fmt.Errorf("replace event budget exceeded after %d attempts: %w", attempt+1, ctx.Err())
+				case <-timer.C:
+				}
 				continue
 			}
 			log.Printf("Serialization conflict replacing kind %d d=%q (attempt %d/%d), giving up",
@@ -501,8 +535,8 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 	return fmt.Errorf("serialization conflict after %d attempts: %w", maxAttempts, err)
 }
 
-func (events *EventStore) replaceEventOnce(evt nostr.Event) error {
-	tx, err := GetDb().BeginTx(context.Background(), &sql.TxOptions{
+func (events *EventStore) replaceEventOnce(ctx context.Context, evt nostr.Event) error {
+	tx, err := GetDb().BeginTx(ctx, &sql.TxOptions{
 		Isolation: sql.LevelSerializable,
 	})
 	if err != nil {

--- a/zooid/events.go
+++ b/zooid/events.go
@@ -499,6 +499,15 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 		if err == nil {
 			return nil
 		}
+		// If our budget elapsed during the attempt (BeginTx parked on the pool
+		// wait queue, or pgx aborted mid-tx because the context expired), the
+		// returned error is wrapped as "failed to begin transaction: context
+		// deadline exceeded" or similar. Re-wrap so callers see the same
+		// "budget exceeded" message we use for the proactive ctx.Err() check
+		// above and the retry-sleep ctx.Done branch — keeps log triage simple.
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return fmt.Errorf("replace event budget exceeded after %d attempts: %w", attempt+1, err)
+		}
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "40001" {
 			if attempt+1 < maxAttempts {

--- a/zooid/events_test.go
+++ b/zooid/events_test.go
@@ -584,6 +584,110 @@ func TestEventStore_ReplaceEvent_SerializationRetry(t *testing.T) {
 	}
 }
 
+// TestEventStore_ReplaceEvent_PoolSaturation_Issue18 reproduces the goroutine
+// leak from issue #18: when the database/sql connection pool is saturated,
+// callers of ReplaceEvent must not park indefinitely on the pool's
+// (unbounded) wait queue. They must time out via the per-call wall-clock
+// budget and return an error so the calling goroutine can exit.
+//
+// The test caps the global pool to a single connection and parks that
+// connection in a held transaction, then fires N concurrent ReplaceEvent
+// calls. Without the fix in events.go (BeginTx with context.Background),
+// every caller would block forever on the pool's wait channel and the test
+// would hang until the Go test runner kills it. With the fix, every caller
+// returns inside the configured budget.
+func TestEventStore_ReplaceEvent_PoolSaturation_Issue18(t *testing.T) {
+	store := createTestEventStore()
+	if err := store.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Shrink the wall-clock budget so the test is fast. Restore on exit so we
+	// don't leak the override into other tests in the same package.
+	origBudget := replaceEventTotalBudget
+	replaceEventTotalBudget = 300 * time.Millisecond
+	defer func() { replaceEventTotalBudget = origBudget }()
+
+	db := GetDb()
+
+	// Save and restore the pool size. We can't read the current value out of
+	// *sql.DB, so restore to the documented default after the test.
+	defer db.SetMaxOpenConns(20)
+	db.SetMaxOpenConns(1)
+
+	// Hold the only connection for the duration of the test by parking a tx.
+	// The blocker uses its own background context so the held tx is not
+	// affected by per-caller deadlines.
+	blockerCtx, cancelBlocker := context.WithCancel(context.Background())
+	defer cancelBlocker()
+
+	blockerReady := make(chan struct{})
+	blockerExited := make(chan struct{})
+	go func() {
+		defer close(blockerExited)
+		tx, err := db.BeginTx(blockerCtx, nil)
+		if err != nil {
+			t.Errorf("blocker BeginTx: %v", err)
+			close(blockerReady)
+			return
+		}
+		// Touch a row so PostgreSQL holds the connection bound to this tx.
+		if _, err := tx.ExecContext(blockerCtx, "SELECT 1"); err != nil {
+			t.Errorf("blocker keepalive query: %v", err)
+		}
+		close(blockerReady)
+		<-blockerCtx.Done()
+		_ = tx.Rollback()
+	}()
+	<-blockerReady
+
+	// Fan out N concurrent ReplaceEvent calls. With a 1-conn pool fully held,
+	// every caller will fail to acquire a connection and must return when the
+	// per-call budget elapses. Pre-fix behavior parks all N goroutines on the
+	// pool wait queue forever and this test hangs.
+	const callers = 50
+	secret := nostr.Generate()
+	done := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func(idx int) {
+			evt := nostr.Event{
+				Kind:      nostr.Kind(30023),
+				CreatedAt: nostr.Timestamp(1_000_000 + idx),
+				Content:   fmt.Sprintf("issue18-%d", idx),
+				Tags:      nostr.Tags{{"d", fmt.Sprintf("issue18-%d", idx)}},
+			}
+			evt.Sign(secret)
+			done <- store.ReplaceEvent(evt)
+		}(i)
+	}
+
+	// Allow generous slack: every caller should finish within a few budget
+	// windows even on a slow CI machine. The point of the assertion is "they
+	// finish at all", not the precise timing.
+	deadline := time.After(5 * replaceEventTotalBudget)
+	returned := 0
+	for returned < callers {
+		select {
+		case err := <-done:
+			returned++
+			if err == nil {
+				t.Errorf("caller %d returned nil error; expected pool-wait timeout", returned)
+			}
+		case <-deadline:
+			t.Fatalf("only %d/%d ReplaceEvent calls returned within %s — goroutines are parked on the pool wait queue (issue #18 regression)",
+				returned, callers, 5*replaceEventTotalBudget)
+		}
+	}
+
+	// Release the held connection and confirm the blocker tx unwinds cleanly.
+	cancelBlocker()
+	select {
+	case <-blockerExited:
+	case <-time.After(time.Second):
+		t.Errorf("blocker goroutine did not exit after cancel")
+	}
+}
+
 func TestEventStore_CountEvents(t *testing.T) {
 	store := createTestEventStore()
 	store.Init()

--- a/zooid/events_test.go
+++ b/zooid/events_test.go
@@ -647,7 +647,11 @@ func TestEventStore_ReplaceEvent_PoolSaturation_Issue18(t *testing.T) {
 	// pool wait queue forever and this test hangs.
 	const callers = 50
 	secret := nostr.Generate()
-	done := make(chan error, callers)
+	type callerResult struct {
+		idx int
+		err error
+	}
+	done := make(chan callerResult, callers)
 	for i := 0; i < callers; i++ {
 		go func(idx int) {
 			evt := nostr.Event{
@@ -657,7 +661,7 @@ func TestEventStore_ReplaceEvent_PoolSaturation_Issue18(t *testing.T) {
 				Tags:      nostr.Tags{{"d", fmt.Sprintf("issue18-%d", idx)}},
 			}
 			evt.Sign(secret)
-			done <- store.ReplaceEvent(evt)
+			done <- callerResult{idx: idx, err: store.ReplaceEvent(evt)}
 		}(i)
 	}
 
@@ -668,10 +672,10 @@ func TestEventStore_ReplaceEvent_PoolSaturation_Issue18(t *testing.T) {
 	returned := 0
 	for returned < callers {
 		select {
-		case err := <-done:
+		case res := <-done:
 			returned++
-			if err == nil {
-				t.Errorf("caller %d returned nil error; expected pool-wait timeout", returned)
+			if res.err == nil {
+				t.Errorf("caller idx=%d returned nil error; expected pool-wait timeout", res.idx)
 			}
 		case <-deadline:
 			t.Fatalf("only %d/%d ReplaceEvent calls returned within %s — goroutines are parked on the pool wait queue (issue #18 regression)",


### PR DESCRIPTION
## Summary

Fixes #18 — the goroutine leak that OOM-killed the `sphere-zooid-relay-eu` task at 2 GiB after ~7h.

- **Root cause:** `ReplaceEvent` and `SaveEvent` called `BeginTx(context.Background(), ...)`, so once PR #17's longer SSI retries (15k-tag SERIALIZABLE saves holding a connection ~2s × up to 6 jittered attempts) exhausted the 20-conn `database/sql` pool, every new caller parked **forever** on the pool's unbounded wait channel. Steady ~5 goroutines/s leak → ~140k goroutines × 10 KB stack at the time of the OOM.
- **Fix:** Wrap `BeginTx` in both paths with `context.WithTimeout` (30s for `SaveEvent`, 60s total for `ReplaceEvent` across all retries). The SSI retry sleep is now `select { <-ctx.Done(); <-timer.C }` so the budget actually fires mid-loop. `replaceEventOnce` takes the parent ctx so per-attempt txs abort on the same deadline.
- **Diagnostics:** `/debug/pprof/` listener gated by `PPROF_ADDR` env var (e.g. `127.0.0.1:6060`). Documented in `README.md` and `CLAUDE.md` with a localhost-only warning.
- **Regression test:** `TestEventStore_ReplaceEvent_PoolSaturation_Issue18` shrinks the pool to 1 conn, parks it in a held tx, fires 50 concurrent `ReplaceEvent` calls. With the pre-fix `BeginTx(context.Background(), ...)` restored the test reports `0/50 ReplaceEvent calls returned within 1.5s`; with the fix it passes in ~350ms.

## Test plan

- [x] `go test ./zooid/` passes (full unit suite, ~5s)
- [x] Verified the regression test catches the bug by temporarily restoring `BeginTx(context.Background(), ...)` in `replaceEventOnce` — test fails with `0/50 returned within 1.5s`
- [ ] Deploy to `sphere-zooid-relay-eu` and watch the Grafana goroutine panel for >7h
- [ ] If a leak still appears, set `PPROF_ADDR=127.0.0.1:6060` and capture `goroutine?debug=2` to localize whatever's left

## Notes

- `replaceEventTotalBudget` and `saveEventTxTimeout` are package-level `var`s (not `const`) so the regression test can shrink them; the production defaults are intentionally ~3× the legitimate worst case so normal load never sees them.
- This does **not** revert any of PR #17's behavior (chunk size, jittered backoff, debouncer). It only adds the missing wall-clock bounds those changes assumed.