### PR TITLE
Bound every runtime DB op with a context timeout (#18)

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -47,8 +47,16 @@ func pprofAddrIsLoopback(addr string) (bool, string) {
 func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 
-	shutdown := make(chan os.Signal, 1)
-	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
+	// rootCtx is the single source of cancellation for the whole process.
+	// Everything that runs inside zooid derives its context from this — no
+	// other place in the codebase calls context.Background(). On SIGINT/
+	// SIGTERM (or stop()) the ctx cancels, which propagates down the tree
+	// to abort in-flight DB ops, fsnotify watcher, metric/retention loops,
+	// etc. Avoiding scattered context.Background() calls also means
+	// graceful shutdown actually stops in-flight goroutines instead of
+	// letting them run their full per-call timeout (issue #18).
+	rootCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	port := zooid.Env("PORT")
 	metricsHandler := promhttp.Handler()
@@ -94,14 +102,19 @@ func main() {
 		}()
 	}
 
-	go zooid.Start()
-	zooid.StartMetricsCollector()
-	zooid.StartRetentionCleaner()
+	go zooid.Start(rootCtx)
+	zooid.StartMetricsCollector(rootCtx)
+	zooid.StartRetentionCleaner(rootCtx)
 
-	<-shutdown
+	<-rootCtx.Done()
 
 	log.Println("\nShutting down gracefully...")
 
+	// Detached shutdown deadline — once SIGTERM has fired, rootCtx is
+	// already canceled, so we need a fresh budget for the http server's
+	// drain. This is the one legitimate context.Background() in the
+	// process: we're past the lifetime of rootCtx and starting a new,
+	// bounded shutdown phase.
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 

--- a/zooid/cache_test.go
+++ b/zooid/cache_test.go
@@ -1,6 +1,7 @@
 package zooid
 
 import (
+	"context"
 	"testing"
 
 	"fiatjaf.com/nostr"
@@ -17,9 +18,10 @@ func createTestGroupStore() (*GroupStore, *ManagementStore) {
 	schema := &Schema{Name: "test_" + RandomString(8)}
 	relay := &khatru.Relay{}
 	events := &EventStore{
-		Relay:  relay,
-		Config: config,
-		Schema: schema,
+		Relay:   relay,
+		Config:  config,
+		Schema:  schema,
+		rootCtx: context.Background(),
 	}
 	events.Init()
 

--- a/zooid/events.go
+++ b/zooid/events.go
@@ -157,11 +157,28 @@ func (events *EventStore) Close() {
 	// Never close the database, since it's a shared resource
 }
 
+// QueryEvents satisfies eventstore.Store. Top-level callers don't have a
+// ctx (the interface signature predates context propagation), so we apply
+// dbOpTimeout inside the iter.Seq closure — this bounds the connection
+// acquire and the query+iteration without holding the timer past the
+// caller's last yield. Internal callers that already own a ctx (e.g.
+// replaceEventOnce) should call queryEventsWith directly and pass it.
 func (events *EventStore) QueryEvents(filter nostr.Filter, maxLimit int) iter.Seq[nostr.Event] {
-	return events.queryEventsWith(GetDb(), filter, maxLimit)
+	return func(yield func(nostr.Event) bool) {
+		ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+		defer cancel()
+		for evt := range events.queryEventsWith(ctx, GetDb(), filter, maxLimit) {
+			if !yield(evt) {
+				return
+			}
+		}
+	}
 }
 
-func (events *EventStore) queryEventsWith(runner squirrel.BaseRunner, filter nostr.Filter, maxLimit int) iter.Seq[nostr.Event] {
+// queryEventsWith runs the read query under the caller's ctx so timeouts
+// and cancellation flow from the parent (e.g. replaceEventOnce's 60s
+// budget). The caller is responsible for setting any deadline on ctx.
+func (events *EventStore) queryEventsWith(ctx context.Context, runner squirrel.BaseRunner, filter nostr.Filter, maxLimit int) iter.Seq[nostr.Event] {
 	return func(yield func(nostr.Event) bool) {
 		if filter.LimitZero {
 			return
@@ -170,15 +187,6 @@ func (events *EventStore) queryEventsWith(runner squirrel.BaseRunner, filter nos
 		if maxLimit > 0 && (filter.Limit == 0 || maxLimit < filter.Limit) {
 			filter.Limit = maxLimit
 		}
-
-		// Per-call deadline — both for the pool acquire (BeginTx-equivalent
-		// happens inside Query) and for the query+iteration. PR #19 bounded
-		// BeginTx in SaveEvent/ReplaceEvent, but this read path was the
-		// dominant leak source in issue #18: pprof showed ~84% of parked
-		// goroutines here, all on `database/sql.(*DB).conn` waiting forever
-		// for a connection from a saturated pool.
-		ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
-		defer cancel()
 
 		observer := QueryDuration.With(prometheus.Labels{"instance": events.Config.Schema})
 		queryStart := time.Now()
@@ -391,13 +399,17 @@ func (events *EventStore) buildTagFilteredQuery(filter nostr.Filter, tagFilters 
 	panic("unreachable — see buildSelectQueryWithTags")
 }
 
+// DeleteEvent satisfies eventstore.Store; applies dbOpTimeout to the
+// delete. Internal callers with their own ctx should call deleteEventWith.
 func (events *EventStore) DeleteEvent(id nostr.ID) error {
-	return events.deleteEventWith(GetDb(), id)
-}
-
-func (events *EventStore) deleteEventWith(runner squirrel.BaseRunner, id nostr.ID) error {
 	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
 	defer cancel()
+	return events.deleteEventWith(ctx, GetDb(), id)
+}
+
+// deleteEventWith runs the delete under the caller's ctx so timeouts flow
+// from the parent (e.g. replaceEventOnce's tx budget).
+func (events *EventStore) deleteEventWith(ctx context.Context, runner squirrel.BaseRunner, id nostr.ID) error {
 	_, err := sb.Delete(events.Schema.Prefix("events")).Where(squirrel.Eq{"id": id.Hex()}).RunWith(runner).ExecContext(ctx)
 	return err
 }
@@ -412,7 +424,7 @@ func (events *EventStore) SaveEvent(evt nostr.Event) error {
 	}
 	defer tx.Rollback()
 
-	if err := events.saveEventWith(tx, evt); err != nil {
+	if err := events.saveEventWith(ctx, tx, evt); err != nil {
 		return err
 	}
 
@@ -420,19 +432,16 @@ func (events *EventStore) SaveEvent(evt nostr.Event) error {
 }
 
 // saveEventWith inserts an event and its tags using the provided runner.
-// The caller is responsible for transaction management.
-//
-// Each Exec uses its own per-call context budget so a saturated pool can't
-// park individual statements forever. The outer SaveEvent / replaceEventOnce
-// budgets bound the total tx wall-clock; this bounds the inner ops.
-func (events *EventStore) saveEventWith(runner squirrel.BaseRunner, evt nostr.Event) error {
+// The caller is responsible for transaction management AND for setting any
+// deadline on `ctx` — every inner Exec uses it, so the entire insert chain
+// (event row + each tag batch) shares one wall-clock budget. This is
+// intentional: ReplaceEvent's 60s and SaveEvent's 30s outer budgets are
+// designed to bound the whole save, not each individual statement.
+func (events *EventStore) saveEventWith(ctx context.Context, runner squirrel.BaseRunner, evt nostr.Event) error {
 	tagsJSON, err := json.Marshal(evt.Tags)
 	if err != nil {
 		return fmt.Errorf("failed to marshal tags: %w", err)
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
-	defer cancel()
 
 	// Insert the event, using ON CONFLICT to atomically detect duplicates.
 	// This is race-safe with PostgreSQL's concurrent connections (unlike SELECT-then-INSERT).
@@ -585,7 +594,7 @@ func (events *EventStore) replaceEventOnce(ctx context.Context, evt nostr.Event)
 
 	shouldSave := true
 	shouldDelete := make([]nostr.ID, 0)
-	for previous := range events.queryEventsWith(tx, filter, 0) {
+	for previous := range events.queryEventsWith(ctx, tx, filter, 0) {
 		if previous.CreatedAt <= evt.CreatedAt {
 			shouldDelete = append(shouldDelete, previous.ID)
 		} else {
@@ -594,13 +603,13 @@ func (events *EventStore) replaceEventOnce(ctx context.Context, evt nostr.Event)
 	}
 
 	if shouldSave {
-		if err := events.saveEventWith(tx, evt); err != nil && err != eventstore.ErrDupEvent {
+		if err := events.saveEventWith(ctx, tx, evt); err != nil && err != eventstore.ErrDupEvent {
 			return fmt.Errorf("failed to save: %w", err)
 		}
 	}
 
 	for _, id := range shouldDelete {
-		if err := events.deleteEventWith(tx, id); err != nil {
+		if err := events.deleteEventWith(ctx, tx, id); err != nil {
 			return fmt.Errorf("failed to delete old event: %w", err)
 		}
 	}

--- a/zooid/events.go
+++ b/zooid/events.go
@@ -75,6 +75,12 @@ type EventStore struct {
 	Relay  *khatru.Relay
 	Config *Config
 	Schema *Schema
+
+	// rootCtx is the service-level root, set by MakeInstance from the
+	// process-wide ctx. All per-call DB timeouts derive from it. Tests
+	// set this to context.Background() via createTestEventStore.
+	// Never read directly outside this package.
+	rootCtx context.Context
 }
 
 var _ eventstore.Store = (*EventStore)(nil)
@@ -111,7 +117,7 @@ func (events *EventStore) Init() error {
 	}
 
 	for _, stmt := range statements {
-		if _, err := GetDb().Exec(stmt); err != nil {
+		if _, err := GetDb().ExecContext(events.rootCtx, stmt); err != nil {
 			return fmt.Errorf("schema init failed: %w", err)
 		}
 	}
@@ -120,7 +126,7 @@ func (events *EventStore) Init() error {
 		return fmt.Errorf("FTS init failed: %w", err)
 	}
 
-	if err := RunMigrations(events.Schema); err != nil {
+	if err := RunMigrations(events.rootCtx, events.Schema); err != nil {
 		return fmt.Errorf("migrations failed: %w", err)
 	}
 
@@ -146,7 +152,7 @@ func (events *EventStore) initFTS() error {
 	}
 
 	for _, stmt := range ftsStatements {
-		if _, err := GetDb().Exec(stmt); err != nil {
+		if _, err := GetDb().ExecContext(events.rootCtx, stmt); err != nil {
 			return fmt.Errorf("statement failed: %w", err)
 		}
 	}
@@ -165,7 +171,7 @@ func (events *EventStore) Close() {
 // replaceEventOnce) should call queryEventsWith directly and pass it.
 func (events *EventStore) QueryEvents(filter nostr.Filter, maxLimit int) iter.Seq[nostr.Event] {
 	return func(yield func(nostr.Event) bool) {
-		ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+		ctx, cancel := context.WithTimeout(events.rootCtx, dbOpTimeout)
 		defer cancel()
 		for evt := range events.queryEventsWith(ctx, GetDb(), filter, maxLimit) {
 			if !yield(evt) {
@@ -402,7 +408,7 @@ func (events *EventStore) buildTagFilteredQuery(filter nostr.Filter, tagFilters 
 // DeleteEvent satisfies eventstore.Store; applies dbOpTimeout to the
 // delete. Internal callers with their own ctx should call deleteEventWith.
 func (events *EventStore) DeleteEvent(id nostr.ID) error {
-	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	ctx, cancel := context.WithTimeout(events.rootCtx, dbOpTimeout)
 	defer cancel()
 	return events.deleteEventWith(ctx, GetDb(), id)
 }
@@ -415,7 +421,7 @@ func (events *EventStore) deleteEventWith(ctx context.Context, runner squirrel.B
 }
 
 func (events *EventStore) SaveEvent(evt nostr.Event) error {
-	ctx, cancel := context.WithTimeout(context.Background(), saveEventTxTimeout)
+	ctx, cancel := context.WithTimeout(events.rootCtx, saveEventTxTimeout)
 	defer cancel()
 
 	tx, err := GetDb().BeginTx(ctx, nil)
@@ -520,7 +526,7 @@ func (events *EventStore) ReplaceEvent(evt nostr.Event) error {
 	//
 	// The whole retry loop runs under a single deadline so a caller can't park
 	// indefinitely on the pool wait queue when the pool is saturated (#18).
-	ctx, cancel := context.WithTimeout(context.Background(), replaceEventTotalBudget)
+	ctx, cancel := context.WithTimeout(events.rootCtx, replaceEventTotalBudget)
 	defer cancel()
 
 	maxAttempts, baseBackoffMs := ssiConfig()
@@ -625,7 +631,7 @@ func (events *EventStore) CountEvents(filter nostr.Filter) (uint32, error) {
 
 	countQb := sb.Select("COUNT(*)").FromSelect(qb, "subquery")
 
-	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	ctx, cancel := context.WithTimeout(events.rootCtx, dbOpTimeout)
 	defer cancel()
 
 	var count uint32

--- a/zooid/events.go
+++ b/zooid/events.go
@@ -49,19 +49,26 @@ func ssiConfig() (int, int) {
 }
 
 // Per-call wall-clock budgets for DB transactions. Without a deadline,
-// BeginTx parks the calling goroutine indefinitely on the database/sql pool's
-// (unbounded) wait channel when the pool is saturated — that's the goroutine
-// leak observed in issue #18 after PR #17, where 15k-tag SERIALIZABLE saves
-// hold pool connections for ~2s and 6 jittered retries push individual
-// ReplaceEvent calls to ~13s, easily exhausting the default 20-conn pool.
+// any database/sql call (BeginTx, Exec, Query, QueryRow) without a context
+// parks the calling goroutine indefinitely on the pool's (unbounded) wait
+// channel when the pool is saturated — that's the goroutine leak in issue
+// #18. PR #19 bounded the BeginTx in SaveEvent/ReplaceEvent; this file's
+// other call sites (queryEventsWith / deleteEventWith / saveEventWith's
+// inner Execs / CountEvents — plus kv.go, metrics.go, retention.go) still
+// used the no-context variants and the leak rerouted through them, with
+// pprof showing ~84% of parked goroutines in QueryEvents.
+//
+// `dbOpTimeout` is the per-call budget used by the *Context variants. It
+// is shared across all runtime DB ops in this package; the outer
+// transaction budgets (`saveEventTxTimeout`, `replaceEventTotalBudget`)
+// stay separate because they bound the *whole* tx including any retries.
 //
 // With these bounds, a contended caller fails fast instead of accumulating.
-// The defaults are chosen to be ~3× the legitimate worst case so normal load
-// doesn't see them. They're var (not const) so the regression test in
-// events_test.go can shrink them to keep the test fast.
+// They're var (not const) so the regression tests can shrink them.
 var (
 	saveEventTxTimeout      = 30 * time.Second
 	replaceEventTotalBudget = 60 * time.Second
+	dbOpTimeout             = 30 * time.Second
 )
 
 type EventStore struct {
@@ -164,9 +171,18 @@ func (events *EventStore) queryEventsWith(runner squirrel.BaseRunner, filter nos
 			filter.Limit = maxLimit
 		}
 
+		// Per-call deadline — both for the pool acquire (BeginTx-equivalent
+		// happens inside Query) and for the query+iteration. PR #19 bounded
+		// BeginTx in SaveEvent/ReplaceEvent, but this read path was the
+		// dominant leak source in issue #18: pprof showed ~84% of parked
+		// goroutines here, all on `database/sql.(*DB).conn` waiting forever
+		// for a connection from a saturated pool.
+		ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+		defer cancel()
+
 		observer := QueryDuration.With(prometheus.Labels{"instance": events.Config.Schema})
 		queryStart := time.Now()
-		rows, err := events.buildSelectQuery(filter).RunWith(runner).Query()
+		rows, err := events.buildSelectQuery(filter).RunWith(runner).QueryContext(ctx)
 		if err != nil {
 			observer.Observe(time.Since(queryStart).Seconds())
 			log.Printf("QueryEvents query error: %v", err)
@@ -380,7 +396,9 @@ func (events *EventStore) DeleteEvent(id nostr.ID) error {
 }
 
 func (events *EventStore) deleteEventWith(runner squirrel.BaseRunner, id nostr.ID) error {
-	_, err := sb.Delete(events.Schema.Prefix("events")).Where(squirrel.Eq{"id": id.Hex()}).RunWith(runner).Exec()
+	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	defer cancel()
+	_, err := sb.Delete(events.Schema.Prefix("events")).Where(squirrel.Eq{"id": id.Hex()}).RunWith(runner).ExecContext(ctx)
 	return err
 }
 
@@ -403,11 +421,18 @@ func (events *EventStore) SaveEvent(evt nostr.Event) error {
 
 // saveEventWith inserts an event and its tags using the provided runner.
 // The caller is responsible for transaction management.
+//
+// Each Exec uses its own per-call context budget so a saturated pool can't
+// park individual statements forever. The outer SaveEvent / replaceEventOnce
+// budgets bound the total tx wall-clock; this bounds the inner ops.
 func (events *EventStore) saveEventWith(runner squirrel.BaseRunner, evt nostr.Event) error {
 	tagsJSON, err := json.Marshal(evt.Tags)
 	if err != nil {
 		return fmt.Errorf("failed to marshal tags: %w", err)
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	defer cancel()
 
 	// Insert the event, using ON CONFLICT to atomically detect duplicates.
 	// This is race-safe with PostgreSQL's concurrent connections (unlike SELECT-then-INSERT).
@@ -424,7 +449,7 @@ func (events *EventStore) saveEventWith(runner squirrel.BaseRunner, evt nostr.Ev
 		).
 		Suffix("ON CONFLICT(id) DO NOTHING")
 
-	result, err := insertQb.RunWith(runner).Exec()
+	result, err := insertQb.RunWith(runner).ExecContext(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to save event '%s': %w", evt.ID, err)
 	}
@@ -455,7 +480,7 @@ func (events *EventStore) saveEventWith(runner squirrel.BaseRunner, evt nostr.Ev
 		batch = batch.Values(eventID, tag[0], tag[1])
 		n++
 		if n >= tagInsertBatchSize {
-			if _, err := batch.RunWith(runner).Exec(); err != nil {
+			if _, err := batch.RunWith(runner).ExecContext(ctx); err != nil {
 				return fmt.Errorf("failed to save tags for event '%s': %w", evt.ID, err)
 			}
 			batch = sb.Insert(tagsTable).Columns("event_id", "key", "value")
@@ -464,7 +489,7 @@ func (events *EventStore) saveEventWith(runner squirrel.BaseRunner, evt nostr.Ev
 	}
 
 	if n > 0 {
-		if _, err := batch.RunWith(runner).Exec(); err != nil {
+		if _, err := batch.RunWith(runner).ExecContext(ctx); err != nil {
 			return fmt.Errorf("failed to save tags for event '%s': %w", evt.ID, err)
 		}
 	}
@@ -591,8 +616,11 @@ func (events *EventStore) CountEvents(filter nostr.Filter) (uint32, error) {
 
 	countQb := sb.Select("COUNT(*)").FromSelect(qb, "subquery")
 
+	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	defer cancel()
+
 	var count uint32
-	err := countQb.RunWith(GetDb()).QueryRow().Scan(&count)
+	err := countQb.RunWith(GetDb()).QueryRowContext(ctx).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count events: %w", err)
 	}

--- a/zooid/events_test.go
+++ b/zooid/events_test.go
@@ -692,6 +692,99 @@ func TestEventStore_ReplaceEvent_PoolSaturation_Issue18(t *testing.T) {
 	}
 }
 
+// withSaturatedPool caps the global db pool to a single connection and parks
+// it in a held tx, then runs body. Restores pool size and unwinds the blocker
+// on return. Used by issue #18 regression tests to prove every code path that
+// touches the pool returns instead of parking forever when the pool is full.
+func withSaturatedPool(t *testing.T, body func()) {
+	t.Helper()
+	db := GetDb()
+	defer db.SetMaxOpenConns(20)
+	db.SetMaxOpenConns(1)
+
+	blockerCtx, cancelBlocker := context.WithCancel(context.Background())
+	defer cancelBlocker()
+
+	blockerReady := make(chan struct{})
+	blockerExited := make(chan struct{})
+	go func() {
+		defer close(blockerExited)
+		tx, err := db.BeginTx(blockerCtx, nil)
+		if err != nil {
+			t.Errorf("blocker BeginTx: %v", err)
+			close(blockerReady)
+			return
+		}
+		if _, err := tx.ExecContext(blockerCtx, "SELECT 1"); err != nil {
+			t.Errorf("blocker keepalive query: %v", err)
+		}
+		close(blockerReady)
+		<-blockerCtx.Done()
+		_ = tx.Rollback()
+	}()
+	<-blockerReady
+
+	body()
+
+	cancelBlocker()
+	select {
+	case <-blockerExited:
+	case <-time.After(time.Second):
+		t.Errorf("blocker goroutine did not exit after cancel")
+	}
+}
+
+// TestEventStore_QueryEvents_PoolSaturation_Issue18 covers the second leak
+// path identified in issue #18: the pprof goroutine dump on sha-67fb306
+// showed ~84% of parked goroutines waiting in QueryEvents.queryEventsWith
+// at events.go:169 — `database/sql.(*DB).Query()` with no context, parked
+// forever on the pool wait queue. PR #19 only bounded BeginTx in
+// SaveEvent/ReplaceEvent so the leak just rerouted through the read path.
+//
+// This test mirrors the ReplaceEvent saturation test for the read path:
+// fire N concurrent QueryEvents iterations against a 1-conn pool that is
+// fully held, and assert each iterator terminates cleanly via the per-call
+// dbOpTimeout instead of hanging.
+func TestEventStore_QueryEvents_PoolSaturation_Issue18(t *testing.T) {
+	store := createTestEventStore()
+	if err := store.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	origTimeout := dbOpTimeout
+	dbOpTimeout = 300 * time.Millisecond
+	defer func() { dbOpTimeout = origTimeout }()
+
+	withSaturatedPool(t, func() {
+		const callers = 50
+		done := make(chan struct{}, callers)
+		for i := 0; i < callers; i++ {
+			go func() {
+				// Drain the iter.Seq fully — that's what khatru's REQ handler
+				// does (`for event := range rl.QueryStored(ctx, filter)`).
+				// Pre-fix this hangs in (*DB).Query waiting for a conn.
+				count := 0
+				for range store.QueryEvents(nostr.Filter{Kinds: []nostr.Kind{nostr.KindTextNote}}, 100) {
+					count++
+				}
+				done <- struct{}{}
+			}()
+		}
+
+		deadline := time.After(5 * dbOpTimeout)
+		returned := 0
+		for returned < callers {
+			select {
+			case <-done:
+				returned++
+			case <-deadline:
+				t.Fatalf("only %d/%d QueryEvents iterators terminated within %s — goroutines are parked on the pool wait queue (issue #18 regression in the read path)",
+					returned, callers, 5*dbOpTimeout)
+			}
+		}
+	})
+}
+
 func TestEventStore_CountEvents(t *testing.T) {
 	store := createTestEventStore()
 	store.Init()

--- a/zooid/events_test.go
+++ b/zooid/events_test.go
@@ -17,8 +17,9 @@ func createTestEventStore() *EventStore {
 		secret: nostr.Generate(),
 	}
 	return &EventStore{
-		Config: config,
-		Schema: schema,
+		Config:  config,
+		Schema:  schema,
+		rootCtx: context.Background(),
 	}
 }
 

--- a/zooid/events_test.go
+++ b/zooid/events_test.go
@@ -609,88 +609,50 @@ func TestEventStore_ReplaceEvent_PoolSaturation_Issue18(t *testing.T) {
 	replaceEventTotalBudget = 300 * time.Millisecond
 	defer func() { replaceEventTotalBudget = origBudget }()
 
-	db := GetDb()
-
-	// Save and restore the pool size. We can't read the current value out of
-	// *sql.DB, so restore to the documented default after the test.
-	defer db.SetMaxOpenConns(20)
-	db.SetMaxOpenConns(1)
-
-	// Hold the only connection for the duration of the test by parking a tx.
-	// The blocker uses its own background context so the held tx is not
-	// affected by per-caller deadlines.
-	blockerCtx, cancelBlocker := context.WithCancel(context.Background())
-	defer cancelBlocker()
-
-	blockerReady := make(chan struct{})
-	blockerExited := make(chan struct{})
-	go func() {
-		defer close(blockerExited)
-		tx, err := db.BeginTx(blockerCtx, nil)
-		if err != nil {
-			t.Errorf("blocker BeginTx: %v", err)
-			close(blockerReady)
-			return
+	withSaturatedPool(t, func() {
+		// Fan out N concurrent ReplaceEvent calls. With a 1-conn pool fully
+		// held, every caller will fail to acquire a connection and must
+		// return when the per-call budget elapses. Pre-fix behavior parks
+		// all N goroutines on the pool wait queue forever and this test
+		// hangs.
+		const callers = 50
+		secret := nostr.Generate()
+		type callerResult struct {
+			idx int
+			err error
 		}
-		// Touch a row so PostgreSQL holds the connection bound to this tx.
-		if _, err := tx.ExecContext(blockerCtx, "SELECT 1"); err != nil {
-			t.Errorf("blocker keepalive query: %v", err)
+		done := make(chan callerResult, callers)
+		for i := 0; i < callers; i++ {
+			go func(idx int) {
+				evt := nostr.Event{
+					Kind:      nostr.Kind(30023),
+					CreatedAt: nostr.Timestamp(1_000_000 + idx),
+					Content:   fmt.Sprintf("issue18-%d", idx),
+					Tags:      nostr.Tags{{"d", fmt.Sprintf("issue18-%d", idx)}},
+				}
+				evt.Sign(secret)
+				done <- callerResult{idx: idx, err: store.ReplaceEvent(evt)}
+			}(i)
 		}
-		close(blockerReady)
-		<-blockerCtx.Done()
-		_ = tx.Rollback()
-	}()
-	<-blockerReady
 
-	// Fan out N concurrent ReplaceEvent calls. With a 1-conn pool fully held,
-	// every caller will fail to acquire a connection and must return when the
-	// per-call budget elapses. Pre-fix behavior parks all N goroutines on the
-	// pool wait queue forever and this test hangs.
-	const callers = 50
-	secret := nostr.Generate()
-	type callerResult struct {
-		idx int
-		err error
-	}
-	done := make(chan callerResult, callers)
-	for i := 0; i < callers; i++ {
-		go func(idx int) {
-			evt := nostr.Event{
-				Kind:      nostr.Kind(30023),
-				CreatedAt: nostr.Timestamp(1_000_000 + idx),
-				Content:   fmt.Sprintf("issue18-%d", idx),
-				Tags:      nostr.Tags{{"d", fmt.Sprintf("issue18-%d", idx)}},
+		// Allow generous slack: every caller should finish within a few
+		// budget windows even on a slow CI machine. The assertion is "they
+		// finish at all", not the precise timing.
+		deadline := time.After(5 * replaceEventTotalBudget)
+		returned := 0
+		for returned < callers {
+			select {
+			case res := <-done:
+				returned++
+				if res.err == nil {
+					t.Errorf("caller idx=%d returned nil error; expected pool-wait timeout", res.idx)
+				}
+			case <-deadline:
+				t.Fatalf("only %d/%d ReplaceEvent calls returned within %s — goroutines are parked on the pool wait queue (issue #18 regression)",
+					returned, callers, 5*replaceEventTotalBudget)
 			}
-			evt.Sign(secret)
-			done <- callerResult{idx: idx, err: store.ReplaceEvent(evt)}
-		}(i)
-	}
-
-	// Allow generous slack: every caller should finish within a few budget
-	// windows even on a slow CI machine. The point of the assertion is "they
-	// finish at all", not the precise timing.
-	deadline := time.After(5 * replaceEventTotalBudget)
-	returned := 0
-	for returned < callers {
-		select {
-		case res := <-done:
-			returned++
-			if res.err == nil {
-				t.Errorf("caller idx=%d returned nil error; expected pool-wait timeout", res.idx)
-			}
-		case <-deadline:
-			t.Fatalf("only %d/%d ReplaceEvent calls returned within %s — goroutines are parked on the pool wait queue (issue #18 regression)",
-				returned, callers, 5*replaceEventTotalBudget)
 		}
-	}
-
-	// Release the held connection and confirm the blocker tx unwinds cleanly.
-	cancelBlocker()
-	select {
-	case <-blockerExited:
-	case <-time.After(time.Second):
-		t.Errorf("blocker goroutine did not exit after cancel")
-	}
+	})
 }
 
 // withSaturatedPool caps the global db pool to a single connection and parks

--- a/zooid/events_test.go
+++ b/zooid/events_test.go
@@ -693,45 +693,63 @@ func TestEventStore_ReplaceEvent_PoolSaturation_Issue18(t *testing.T) {
 }
 
 // withSaturatedPool caps the global db pool to a single connection and parks
-// it in a held tx, then runs body. Restores pool size and unwinds the blocker
-// on return. Used by issue #18 regression tests to prove every code path that
-// touches the pool returns instead of parking forever when the pool is full.
+// it in a held tx, then runs body. Restores the original pool size and
+// unwinds the blocker on return — even if body calls t.Fatal/FailNow (which
+// uses runtime.Goexit and skips non-deferred cleanup). Used by issue #18
+// regression tests to prove every code path that touches the pool returns
+// instead of parking forever when the pool is full.
 func withSaturatedPool(t *testing.T, body func()) {
 	t.Helper()
 	db := GetDb()
-	defer db.SetMaxOpenConns(20)
+
+	// Capture the live pool size so we don't leak a hard-coded value into
+	// other tests that may have set DB_MAX_OPEN_CONNS differently.
+	origMaxOpen := db.Stats().MaxOpenConnections
+	defer db.SetMaxOpenConns(origMaxOpen)
 	db.SetMaxOpenConns(1)
 
 	blockerCtx, cancelBlocker := context.WithCancel(context.Background())
 	defer cancelBlocker()
 
-	blockerReady := make(chan struct{})
+	// Surface blocker setup failures to the main goroutine so the test fails
+	// before body() runs against an unsaturated pool — otherwise a silent
+	// blocker failure would let body() succeed against a normal-sized pool
+	// and mask leak regressions.
+	blockerReady := make(chan error, 1)
 	blockerExited := make(chan struct{})
 	go func() {
 		defer close(blockerExited)
 		tx, err := db.BeginTx(blockerCtx, nil)
 		if err != nil {
-			t.Errorf("blocker BeginTx: %v", err)
-			close(blockerReady)
+			blockerReady <- fmt.Errorf("BeginTx: %w", err)
 			return
 		}
 		if _, err := tx.ExecContext(blockerCtx, "SELECT 1"); err != nil {
-			t.Errorf("blocker keepalive query: %v", err)
+			_ = tx.Rollback()
+			blockerReady <- fmt.Errorf("keepalive: %w", err)
+			return
 		}
-		close(blockerReady)
+		blockerReady <- nil
 		<-blockerCtx.Done()
 		_ = tx.Rollback()
 	}()
-	<-blockerReady
+	if err := <-blockerReady; err != nil {
+		t.Fatalf("withSaturatedPool: blocker setup failed (pool not actually saturated): %v", err)
+	}
+
+	// Defer unwinding so it runs even if body t.Fatal's via runtime.Goexit.
+	// Without this, a fatal in body() would leave the blocker goroutine
+	// holding the conn and bleed into subsequent tests in the package.
+	defer func() {
+		cancelBlocker()
+		select {
+		case <-blockerExited:
+		case <-time.After(time.Second):
+			t.Errorf("blocker goroutine did not exit after cancel")
+		}
+	}()
 
 	body()
-
-	cancelBlocker()
-	select {
-	case <-blockerExited:
-	case <-time.After(time.Second):
-		t.Errorf("blocker goroutine did not exit after cancel")
-	}
 }
 
 // TestEventStore_QueryEvents_PoolSaturation_Issue18 covers the second leak

--- a/zooid/instance.go
+++ b/zooid/instance.go
@@ -18,6 +18,11 @@ import (
 )
 
 type Instance struct {
+	// Ctx is the service-level root context, propagated from main via
+	// signal.NotifyContext. Stored here so per-call DB timeouts in
+	// EventStore/etc. can derive from it instead of context.Background().
+	// Cancellation flows through on SIGTERM, aborting in-flight work.
+	Ctx        context.Context
 	Relay      *khatru.Relay
 	Config     *Config
 	Events     *EventStore
@@ -26,7 +31,7 @@ type Instance struct {
 	Groups     *GroupStore
 }
 
-func MakeInstance(filename string) (*Instance, error) {
+func MakeInstance(ctx context.Context, filename string) (*Instance, error) {
 	config, err := LoadConfig(filename)
 	if err != nil {
 		return nil, err
@@ -47,6 +52,7 @@ func MakeInstance(filename string) (*Instance, error) {
 		Schema: &Schema{
 			Name: slug.Make(config.Schema),
 		},
+		rootCtx: ctx,
 	}
 
 	blossom := &BlossomStore{
@@ -71,6 +77,7 @@ func MakeInstance(filename string) (*Instance, error) {
 	}
 
 	instance := &Instance{
+		Ctx:        ctx,
 		Relay:      relay,
 		Config:     config,
 		Events:     events,

--- a/zooid/instance_test.go
+++ b/zooid/instance_test.go
@@ -40,9 +40,10 @@ func createTestInstance() *Instance {
 	relay := &khatru.Relay{}
 
 	events := &EventStore{
-		Relay:  relay,
-		Config: config,
-		Schema: schema,
+		Relay:   relay,
+		Config:  config,
+		Schema:  schema,
+		rootCtx: context.Background(),
 	}
 
 	management := &ManagementStore{

--- a/zooid/kv.go
+++ b/zooid/kv.go
@@ -2,10 +2,17 @@ package zooid
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
 )
+
+// ErrKVNotFound is the sentinel returned by KeyValueStore.Get when the key
+// doesn't exist. Callers must `errors.Is(err, ErrKVNotFound)` instead of
+// treating any error as missing — context deadlines and DB faults look
+// indistinguishable from "no row" if you only inspect the bool/string.
+var ErrKVNotFound = errors.New("kv key not found")
 
 var (
 	kv     *KeyValueStore
@@ -36,7 +43,13 @@ func (kv *KeyValueStore) Migrate(ctx context.Context) {
 	}
 
 	for _, stmt := range statements {
-		if _, err := GetDb().ExecContext(ctx, stmt); err != nil {
+		// Per-statement deadline — the caller's ctx may be the long-lived
+		// service root, which has no timeout, so a stalled DB at startup
+		// would otherwise hang here forever.
+		subctx, cancel := context.WithTimeout(ctx, dbOpTimeout)
+		_, err := GetDb().ExecContext(subctx, stmt)
+		cancel()
+		if err != nil {
 			log.Fatalf("failed to migrate database: %v", err)
 		}
 	}
@@ -72,7 +85,14 @@ func (kv *KeyValueStore) Get(ctx context.Context, key string) (string, error) {
 		return value, nil
 	}
 
-	return "", fmt.Errorf("%s not found", key)
+	// rows.Err() surfaces context-cancel and driver errors that ended the
+	// iteration before any row arrived — without this check, the not-found
+	// branch below would mask them.
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("kv get %q: %w", key, err)
+	}
+
+	return "", fmt.Errorf("%w: %s", ErrKVNotFound, key)
 }
 
 func (kv *KeyValueStore) Set(ctx context.Context, key string, value string) error {

--- a/zooid/kv.go
+++ b/zooid/kv.go
@@ -1,6 +1,7 @@
 package zooid
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -38,11 +39,14 @@ func (kv *KeyValueStore) Migrate() {
 }
 
 func (kv *KeyValueStore) Get(key string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	defer cancel()
+
 	rows, err := sb.Select("value").
 		From("kv").
 		Where("key = ?", key).
 		RunWith(GetDb()).
-		Query()
+		QueryContext(ctx)
 
 	if err != nil {
 		return "", err
@@ -65,12 +69,15 @@ func (kv *KeyValueStore) Get(key string) (string, error) {
 }
 
 func (kv *KeyValueStore) Set(key string, value string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	defer cancel()
+
 	_, err := sb.Insert("kv").
 		Columns("key", "value").
 		Values(key, value).
 		Suffix("ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value").
 		RunWith(GetDb()).
-		Exec()
+		ExecContext(ctx)
 
 	return err
 }

--- a/zooid/kv.go
+++ b/zooid/kv.go
@@ -14,16 +14,20 @@ var (
 
 type KeyValueStore struct{}
 
-func GetKeyValueStore() *KeyValueStore {
+// GetKeyValueStore is a startup-time singleton — Migrate creates the kv
+// table once, before the connection pool sees production load. The ctx is
+// used for the table-create Exec so a stalled DB during boot fails fast
+// instead of hanging forever.
+func GetKeyValueStore(ctx context.Context) *KeyValueStore {
 	kvOnce.Do(func() {
 		kv = &KeyValueStore{}
-		kv.Migrate()
+		kv.Migrate(ctx)
 	})
 
 	return kv
 }
 
-func (kv *KeyValueStore) Migrate() {
+func (kv *KeyValueStore) Migrate(ctx context.Context) {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS kv (
 			key TEXT PRIMARY KEY,
@@ -32,21 +36,24 @@ func (kv *KeyValueStore) Migrate() {
 	}
 
 	for _, stmt := range statements {
-		if _, err := GetDb().Exec(stmt); err != nil {
+		if _, err := GetDb().ExecContext(ctx, stmt); err != nil {
 			log.Fatalf("failed to migrate database: %v", err)
 		}
 	}
 }
 
-func (kv *KeyValueStore) Get(key string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+// Get/Set take ctx so the caller's deadline (derived from the service root
+// ctx) bounds the pool wait and query — no business code creates its own
+// background context.
+func (kv *KeyValueStore) Get(ctx context.Context, key string) (string, error) {
+	subctx, cancel := context.WithTimeout(ctx, dbOpTimeout)
 	defer cancel()
 
 	rows, err := sb.Select("value").
 		From("kv").
 		Where("key = ?", key).
 		RunWith(GetDb()).
-		QueryContext(ctx)
+		QueryContext(subctx)
 
 	if err != nil {
 		return "", err
@@ -68,8 +75,8 @@ func (kv *KeyValueStore) Get(key string) (string, error) {
 	return "", fmt.Errorf("%s not found", key)
 }
 
-func (kv *KeyValueStore) Set(key string, value string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+func (kv *KeyValueStore) Set(ctx context.Context, key string, value string) error {
+	subctx, cancel := context.WithTimeout(ctx, dbOpTimeout)
 	defer cancel()
 
 	_, err := sb.Insert("kv").
@@ -77,12 +84,14 @@ func (kv *KeyValueStore) Set(key string, value string) error {
 		Values(key, value).
 		Suffix("ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value").
 		RunWith(GetDb()).
-		ExecContext(ctx)
+		ExecContext(subctx)
 
 	return err
 }
 
-// Namespaced kv
+// Namespaced kv. Currently unused by anything in the codebase but exposed
+// for future callers; kept ctx-aware for the same reason as the underlying
+// KeyValueStore.
 
 type KV struct {
 	Name string
@@ -92,10 +101,10 @@ func (kv *KV) Key(key string) string {
 	return fmt.Sprintf("%s:%s", kv.Name, key)
 }
 
-func (kv *KV) Get(key string) (string, error) {
-	return GetKeyValueStore().Get(kv.Key(key))
+func (kv *KV) Get(ctx context.Context, key string) (string, error) {
+	return GetKeyValueStore(ctx).Get(ctx, kv.Key(key))
 }
 
-func (kv *KV) Set(key string, value string) error {
-	return GetKeyValueStore().Set(kv.Key(key), value)
+func (kv *KV) Set(ctx context.Context, key string, value string) error {
+	return GetKeyValueStore(ctx).Set(ctx, kv.Key(key), value)
 }

--- a/zooid/lib.go
+++ b/zooid/lib.go
@@ -1,6 +1,7 @@
 package zooid
 
 import (
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -25,7 +26,12 @@ func Dispatch(hostname string) (*Instance, bool) {
 	return instance, exists
 }
 
-func Start() {
+// Start blocks until ctx is canceled. ctx is the service-level root context
+// (created once in main from signal.NotifyContext) — every Instance built
+// here stores it on Instance.Ctx, and every per-call DB timeout in this
+// package derives from it. SIGTERM cancels ctx → in-flight DB ops abort
+// instead of running their full per-op budget against a dying process.
+func Start(ctx context.Context) {
 	mediaDir := Env("MEDIA")
 	if err := os.MkdirAll(mediaDir, 0755); err != nil {
 		log.Fatalf("Failed to create media directory: %v", err)
@@ -50,7 +56,7 @@ func Start() {
 			continue
 		}
 
-		instance, err := MakeInstance(entry.Name())
+		instance, err := MakeInstance(ctx, entry.Name())
 
 		if err != nil {
 			log.Printf("Failed to make instance for %s: %v", entry.Name(), err)
@@ -89,6 +95,13 @@ func Start() {
 
 	for {
 		select {
+		case <-ctx.Done():
+			// Service shutting down — stop watching for config changes and
+			// release the watcher's fd. In-flight DB ops on individual
+			// instances abort via their derived contexts; that's handled
+			// at each call site, not here.
+			return
+
 		case event, ok := <-watcher.Events:
 			if !ok {
 				return
@@ -109,7 +122,7 @@ func Start() {
 				if event.Has(fsnotify.Remove) {
 					log.Printf("Unloaded %s", filename)
 				} else {
-					instance, err := MakeInstance(filename)
+					instance, err := MakeInstance(ctx, filename)
 					if err != nil {
 						log.Printf("Failed to reload %s: %v", filename, err)
 					} else {

--- a/zooid/management_test.go
+++ b/zooid/management_test.go
@@ -1,6 +1,7 @@
 package zooid
 
 import (
+	"context"
 	"testing"
 
 	"fiatjaf.com/nostr"
@@ -15,9 +16,10 @@ func createTestManagementStore() *ManagementStore {
 	schema := &Schema{Name: "test_" + RandomString(8)}
 	relay := &khatru.Relay{}
 	events := &EventStore{
-		Relay:  relay,
-		Config: config,
-		Schema: schema,
+		Relay:   relay,
+		Config:  config,
+		Schema:  schema,
+		rootCtx: context.Background(),
 	}
 	events.Init()
 

--- a/zooid/metrics.go
+++ b/zooid/metrics.go
@@ -405,4 +405,11 @@ func collectGroupMessageCounts(inst *Instance, instLabel string) {
 			"group":    group,
 		}).Set(float64(count))
 	}
+	// Surface mid-iteration failures (e.g. context deadline exceeded under
+	// pool contention) so we don't silently emit partial group-message
+	// metrics — the per-group counts published before the error are still
+	// recorded but at least operators see something is wrong.
+	if err := rows.Err(); err != nil {
+		log.Printf("metrics: group message counts iteration error: %v", err)
+	}
 }

--- a/zooid/metrics.go
+++ b/zooid/metrics.go
@@ -130,27 +130,39 @@ const maxTrackedGroups = 1000
 
 // StartMetricsCollector launches background goroutines that update
 // Prometheus metrics. Most metrics refresh every 30 seconds; per-group
-// message counts run every 2 minutes to reduce CPU load.
-func StartMetricsCollector() {
+// message counts run every 2 minutes to reduce CPU load. ctx is the
+// service root: when canceled (SIGTERM), both tickers exit and any
+// in-flight DB query aborts via the per-call derived contexts.
+func StartMetricsCollector(ctx context.Context) {
 	go func() {
-		collectMetrics()
+		collectMetrics(ctx)
 
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			collectMetrics()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				collectMetrics(ctx)
+			}
 		}
 	}()
 
 	go func() {
-		collectGroupMessages()
+		collectGroupMessages(ctx)
 
 		ticker := time.NewTicker(2 * time.Minute)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			collectGroupMessages()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				collectGroupMessages(ctx)
+			}
 		}
 	}()
 }
@@ -159,7 +171,7 @@ func StartMetricsCollector() {
 // so we can clean up metrics for unloaded instances.
 var activeInstances = make(map[string]struct{})
 
-func collectMetrics() {
+func collectMetrics(ctx context.Context) {
 	collectMu.Lock()
 	defer collectMu.Unlock()
 
@@ -170,7 +182,7 @@ func collectMetrics() {
 		label := instanceLabel(inst)
 		currentInstances[label] = struct{}{}
 		collectCacheMetrics(inst)
-		collectDBMetrics(inst)
+		collectDBMetrics(ctx, inst)
 	}
 
 	// Delete metrics for instances that were unloaded since last cycle.
@@ -281,7 +293,7 @@ func collectCacheMetrics(inst *Instance) {
 	bannedEventsTotal.With(label).Set(bannedEvCount)
 }
 
-func collectDBMetrics(inst *Instance) {
+func collectDBMetrics(ctx context.Context, inst *Instance) {
 	instLabel := instanceLabel(inst)
 	label := prometheus.Labels{"instance": instLabel}
 	eventsTable := inst.Events.Schema.Prefix("events")
@@ -289,12 +301,12 @@ func collectDBMetrics(inst *Instance) {
 	// Use Postgres reltuples estimate — no sequential scan, instant.
 	// GREATEST handles -1 (never-analyzed tables). PostgreSQL lowercases
 	// unquoted identifiers, so match against lowercase.
-	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	subctx, cancel := context.WithTimeout(ctx, dbOpTimeout)
 	defer cancel()
 
 	var eventsEst float64
 	err := GetDb().QueryRowContext(
-		ctx,
+		subctx,
 		"SELECT GREATEST(COALESCE(reltuples, 0), 0) FROM pg_class WHERE relname = $1",
 		strings.ToLower(eventsTable),
 	).Scan(&eventsEst)
@@ -319,7 +331,7 @@ var (
 	activeGroupMessageInstances = make(map[string]struct{})
 )
 
-func collectGroupMessages() {
+func collectGroupMessages(ctx context.Context) {
 	groupMessagesMu.Lock()
 	defer groupMessagesMu.Unlock()
 
@@ -330,7 +342,7 @@ func collectGroupMessages() {
 		instLabel := instanceLabel(inst)
 		currentInstances[instLabel] = struct{}{}
 		groupMessages.DeletePartialMatch(prometheus.Labels{"instance": instLabel})
-		collectGroupMessageCounts(inst, instLabel)
+		collectGroupMessageCounts(ctx, inst, instLabel)
 	}
 
 	for label := range activeGroupMessageInstances {
@@ -341,7 +353,7 @@ func collectGroupMessages() {
 	activeGroupMessageInstances = currentInstances
 }
 
-func collectGroupMessageCounts(inst *Instance, instLabel string) {
+func collectGroupMessageCounts(ctx context.Context, inst *Instance, instLabel string) {
 	// Collect visible group IDs (not private, not hidden), capped at maxTrackedGroups.
 	visibleGroups := make([]string, 0, maxTrackedGroups)
 	inst.Groups.metadataCache.Range(func(key, value any) bool {
@@ -384,10 +396,10 @@ func collectGroupMessageCounts(inst *Instance, instLabel string) {
 		Where(squirrel.Eq{"e.kind": kindArgs}).
 		GroupBy("t.value")
 
-	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	subctx, cancel := context.WithTimeout(ctx, dbOpTimeout)
 	defer cancel()
 
-	rows, err := qb.RunWith(GetDb()).QueryContext(ctx)
+	rows, err := qb.RunWith(GetDb()).QueryContext(subctx)
 	if err != nil {
 		log.Printf("metrics: failed to query group message counts: %v", err)
 		return

--- a/zooid/metrics.go
+++ b/zooid/metrics.go
@@ -1,6 +1,7 @@
 package zooid
 
 import (
+	"context"
 	"log"
 	"strings"
 	"sync"
@@ -288,8 +289,12 @@ func collectDBMetrics(inst *Instance) {
 	// Use Postgres reltuples estimate — no sequential scan, instant.
 	// GREATEST handles -1 (never-analyzed tables). PostgreSQL lowercases
 	// unquoted identifiers, so match against lowercase.
+	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	defer cancel()
+
 	var eventsEst float64
-	err := GetDb().QueryRow(
+	err := GetDb().QueryRowContext(
+		ctx,
 		"SELECT GREATEST(COALESCE(reltuples, 0), 0) FROM pg_class WHERE relname = $1",
 		strings.ToLower(eventsTable),
 	).Scan(&eventsEst)
@@ -379,7 +384,10 @@ func collectGroupMessageCounts(inst *Instance, instLabel string) {
 		Where(squirrel.Eq{"e.kind": kindArgs}).
 		GroupBy("t.value")
 
-	rows, err := qb.RunWith(GetDb()).Query()
+	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	defer cancel()
+
+	rows, err := qb.RunWith(GetDb()).QueryContext(ctx)
 	if err != nil {
 		log.Printf("metrics: failed to query group message counts: %v", err)
 		return

--- a/zooid/metrics_test.go
+++ b/zooid/metrics_test.go
@@ -1,6 +1,7 @@
 package zooid
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -21,9 +22,10 @@ func createMetricsTestInstance(t *testing.T) *Instance {
 	schema := &Schema{Name: config.Schema}
 	relay := khatru.NewRelay()
 	events := &EventStore{
-		Relay:  relay,
-		Config: config,
-		Schema: schema,
+		Relay:   relay,
+		Config:  config,
+		Schema:  schema,
+		rootCtx: context.Background(),
 	}
 	if err := events.Init(); err != nil {
 		t.Fatalf("events.Init failed: %v", err)
@@ -117,7 +119,7 @@ func TestMetrics_CacheGauges(t *testing.T) {
 	inst.Management.bannedEvents.Store(fakeEvt.ID, "abuse")
 
 	withTestInstance(t, inst, func() {
-		collectMetrics()
+		collectMetrics(context.Background())
 	})
 
 	// Group counts
@@ -199,8 +201,8 @@ func TestMetrics_DBGauges(t *testing.T) {
 	}
 
 	withTestInstance(t, inst, func() {
-		collectMetrics()
-		collectGroupMessages()
+		collectMetrics(context.Background())
+		collectGroupMessages(context.Background())
 	})
 
 	// eventsTotal uses reltuples estimate — after ANALYZE it should be accurate
@@ -240,7 +242,7 @@ func TestMetrics_GroupMembersCap(t *testing.T) {
 	}
 
 	withTestInstance(t, inst, func() {
-		collectMetrics()
+		collectMetrics(context.Background())
 	})
 
 	// groupsTracked should be capped at 1000
@@ -267,7 +269,7 @@ func TestMetrics_StaleGroupsCleared(t *testing.T) {
 	})
 
 	withTestInstance(t, inst, func() {
-		collectMetrics()
+		collectMetrics(context.Background())
 	})
 
 	if v := testutil.ToFloat64(groupMembers.WithLabelValues(label, "old-group")); v != 1 {
@@ -278,7 +280,7 @@ func TestMetrics_StaleGroupsCleared(t *testing.T) {
 	inst.Groups.membershipCache.Delete("old-group")
 	inst.Groups.metadataCache.Delete("old-group")
 	withTestInstance(t, inst, func() {
-		collectMetrics()
+		collectMetrics(context.Background())
 	})
 
 	// After DeletePartialMatch, the stale gauge should be 0
@@ -307,7 +309,7 @@ func TestMetrics_PrivateGroupsNotExposed(t *testing.T) {
 	})
 
 	withTestInstance(t, inst, func() {
-		collectMetrics()
+		collectMetrics(context.Background())
 	})
 
 	// Public group should be tracked
@@ -367,7 +369,7 @@ func TestMetrics_ConcurrentCollect(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				collectMetrics()
+				collectMetrics(context.Background())
 			}()
 		}
 		wg.Wait()
@@ -400,7 +402,7 @@ func TestMetrics_MultipleInstances(t *testing.T) {
 		instancesMux.Unlock()
 	}()
 
-	collectMetrics()
+	collectMetrics(context.Background())
 
 	// Each instance should have its own metric
 	if v := testutil.ToFloat64(groupsTotal.WithLabelValues(inst1.Config.Schema)); v != 1 {

--- a/zooid/migrate.go
+++ b/zooid/migrate.go
@@ -3,6 +3,7 @@ package zooid
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -40,9 +41,16 @@ func RunMigrations(ctx context.Context, schema *Schema) error {
 
 		kvKey := fmt.Sprintf("migration:%s:%s", schema.Name, entry.Name())
 
-		if _, err := kv.Get(ctx, kvKey); err == nil {
-			// Already applied.
+		// Distinguish "key not found" (migration pending) from any other
+		// error (ctx cancel, DB fault). Treating all errors as "not found"
+		// would silently re-run migrations against a sick DB, risking
+		// duplicate-apply effects on non-idempotent migrations.
+		_, err := kv.Get(ctx, kvKey)
+		if err == nil {
 			continue
+		}
+		if !errors.Is(err, ErrKVNotFound) {
+			return fmt.Errorf("checking migration %s applied state: %w", entry.Name(), err)
 		}
 
 		raw, err := migrationFiles.ReadFile("migrations/" + entry.Name())
@@ -52,13 +60,20 @@ func RunMigrations(ctx context.Context, schema *Schema) error {
 
 		rendered := schema.Render(string(raw))
 
-		// Split on semicolons to execute each statement individually.
+		// Split on semicolons to execute each statement individually. Each
+		// statement gets a fresh per-statement deadline derived from ctx —
+		// the caller's ctx is typically the long-lived service root with no
+		// deadline, so without this a stalled DB at startup hangs forever
+		// despite ExecContext being used.
 		for _, stmt := range strings.Split(rendered, ";") {
 			stmt = strings.TrimSpace(stmt)
 			if stmt == "" {
 				continue
 			}
-			if _, err := GetDb().ExecContext(ctx, stmt); err != nil {
+			subctx, cancel := context.WithTimeout(ctx, dbOpTimeout)
+			_, err := GetDb().ExecContext(subctx, stmt)
+			cancel()
+			if err != nil {
 				return fmt.Errorf("migration %s failed: %w", entry.Name(), err)
 			}
 		}

--- a/zooid/migrate.go
+++ b/zooid/migrate.go
@@ -1,6 +1,7 @@
 package zooid
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"log"
@@ -15,8 +16,12 @@ var migrationFiles embed.FS
 // Migrations are embedded from zooid/migrations/, templated with the schema
 // prefix, and tracked in the global kv table so each runs at most once per
 // schema. Statements within a file are split on ";" and executed individually.
-func RunMigrations(schema *Schema) error {
-	kv := GetKeyValueStore()
+//
+// ctx is the service root context; it bounds the kv lookups, kv writes, and
+// the migration Execs so a stalled DB at startup fails fast instead of
+// hanging the boot.
+func RunMigrations(ctx context.Context, schema *Schema) error {
+	kv := GetKeyValueStore(ctx)
 
 	entries, err := migrationFiles.ReadDir("migrations")
 	if err != nil {
@@ -35,7 +40,7 @@ func RunMigrations(schema *Schema) error {
 
 		kvKey := fmt.Sprintf("migration:%s:%s", schema.Name, entry.Name())
 
-		if _, err := kv.Get(kvKey); err == nil {
+		if _, err := kv.Get(ctx, kvKey); err == nil {
 			// Already applied.
 			continue
 		}
@@ -53,12 +58,12 @@ func RunMigrations(schema *Schema) error {
 			if stmt == "" {
 				continue
 			}
-			if _, err := GetDb().Exec(stmt); err != nil {
+			if _, err := GetDb().ExecContext(ctx, stmt); err != nil {
 				return fmt.Errorf("migration %s failed: %w", entry.Name(), err)
 			}
 		}
 
-		if err := kv.Set(kvKey, "applied"); err != nil {
+		if err := kv.Set(ctx, kvKey, "applied"); err != nil {
 			return fmt.Errorf("recording migration %s: %w", entry.Name(), err)
 		}
 

--- a/zooid/migrate_test.go
+++ b/zooid/migrate_test.go
@@ -1,6 +1,7 @@
 package zooid
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -10,10 +11,10 @@ func TestRunMigrations_AppliesAndTracks(t *testing.T) {
 	store := createTestEventStore()
 	store.Init()
 
-	kv := GetKeyValueStore()
+	kv := GetKeyValueStore(context.Background())
 
 	key := fmt.Sprintf("migration:%s:001_covering_indexes.sql", store.Schema.Name)
-	val, err := kv.Get(key)
+	val, err := kv.Get(context.Background(), key)
 	if err != nil {
 		t.Fatalf("Migration not tracked in kv: %v", err)
 	}
@@ -26,7 +27,7 @@ func TestRunMigrations_Idempotent(t *testing.T) {
 	store := createTestEventStore()
 	store.Init()
 
-	if err := RunMigrations(store.Schema); err != nil {
+	if err := RunMigrations(context.Background(), store.Schema); err != nil {
 		t.Fatalf("Second RunMigrations() failed: %v", err)
 	}
 }

--- a/zooid/retention.go
+++ b/zooid/retention.go
@@ -2,6 +2,7 @@ package zooid
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -102,50 +103,58 @@ func cleanExpiredMessages() {
 	activeRetentionInstances = currentInstances
 }
 
-func deleteExpiredGroupMessages(inst *Instance, groupID string, cutoff int64) int64 {
+// deleteOneRetentionBatch runs one bounded DELETE batch. Pulled out so the
+// per-iteration ctx can use `defer cancel()` and survive any future early
+// returns added inside the batch logic.
+func deleteOneRetentionBatch(inst *Instance, groupID string, cutoff int64) (rowsAffected int64, more bool, err error) {
 	eventsTable := inst.Events.Schema.Prefix("events")
 	tagsTable := inst.Events.Schema.Prefix("event_tags")
 
+	subquery := sb.Select("DISTINCT e.id").
+		From(eventsTable + " e").
+		Join(tagsTable + " t ON t.event_id = e.id").
+		Where(squirrel.Eq{"t.key": "h"}).
+		Where(squirrel.Eq{"t.value": groupID}).
+		Where(squirrel.Eq{"e.kind": []int{9, 10}}).
+		Where(squirrel.Lt{"e.created_at": cutoff}).
+		Limit(retentionDeleteBatchSize)
+
+	subSQL, subArgs, err := subquery.ToSql()
+	if err != nil {
+		return 0, false, fmt.Errorf("build subquery: %w", err)
+	}
+
+	// DELETE FROM events WHERE id IN (subquery)
+	// CASCADE on event_tags foreign key handles tag cleanup.
+	deleteSQL := "DELETE FROM " + eventsTable + " WHERE id IN (" + subSQL + ")"
+
+	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	defer cancel()
+
+	result, err := GetDb().ExecContext(ctx, deleteSQL, subArgs...)
+	if err != nil {
+		return 0, false, fmt.Errorf("exec delete: %w", err)
+	}
+
+	rowsAffected, err = result.RowsAffected()
+	if err != nil {
+		return 0, false, fmt.Errorf("rows affected: %w", err)
+	}
+	return rowsAffected, rowsAffected >= retentionDeleteBatchSize, nil
+}
+
+func deleteExpiredGroupMessages(inst *Instance, groupID string, cutoff int64) int64 {
 	var totalDeleted int64
 	for {
-		subquery := sb.Select("DISTINCT e.id").
-			From(eventsTable + " e").
-			Join(tagsTable + " t ON t.event_id = e.id").
-			Where(squirrel.Eq{"t.key": "h"}).
-			Where(squirrel.Eq{"t.value": groupID}).
-			Where(squirrel.Eq{"e.kind": []int{9, 10}}).
-			Where(squirrel.Lt{"e.created_at": cutoff}).
-			Limit(retentionDeleteBatchSize)
-
-		subSQL, subArgs, err := subquery.ToSql()
+		rows, more, err := deleteOneRetentionBatch(inst, groupID, cutoff)
 		if err != nil {
-			log.Printf("retention: failed to build subquery for group %q: %v", groupID, err)
+			log.Printf("retention: %s for group %q", err, groupID)
 			return totalDeleted
 		}
-
-		// DELETE FROM events WHERE id IN (subquery)
-		// CASCADE on event_tags foreign key handles tag cleanup.
-		deleteSQL := "DELETE FROM " + eventsTable + " WHERE id IN (" + subSQL + ")"
-
-		ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
-		result, err := GetDb().ExecContext(ctx, deleteSQL, subArgs...)
-		cancel()
-		if err != nil {
-			log.Printf("retention: failed to delete messages for group %q: %v", groupID, err)
-			return totalDeleted
-		}
-
-		rows, err := result.RowsAffected()
-		if err != nil {
-			log.Printf("retention: failed to get rows affected for group %q: %v", groupID, err)
-			return totalDeleted
-		}
-
 		totalDeleted += rows
-		if rows < retentionDeleteBatchSize {
+		if !more {
 			break
 		}
 	}
-
 	return totalDeleted
 }

--- a/zooid/retention.go
+++ b/zooid/retention.go
@@ -34,16 +34,23 @@ func init() {
 
 // StartRetentionCleaner launches a background goroutine that periodically
 // deletes expired chat messages (kinds 9, 10) based on per-group retention
-// policies defined in the TOML config.
-func StartRetentionCleaner() {
+// policies defined in the TOML config. ctx is the service root context;
+// when it cancels (SIGTERM), the cleaner exits and any in-flight DELETE
+// aborts via the per-batch derived context.
+func StartRetentionCleaner(ctx context.Context) {
 	go func() {
-		cleanExpiredMessages()
+		cleanExpiredMessages(ctx)
 
 		ticker := time.NewTicker(1 * time.Minute)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			cleanExpiredMessages()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cleanExpiredMessages(ctx)
+			}
 		}
 	}()
 }
@@ -52,7 +59,7 @@ func StartRetentionCleaner() {
 // cleanup cycle, so we can clean up metrics for unloaded instances.
 var activeRetentionInstances = make(map[string]struct{})
 
-func cleanExpiredMessages() {
+func cleanExpiredMessages(ctx context.Context) {
 	retentionMu.Lock()
 	defer retentionMu.Unlock()
 
@@ -78,7 +85,7 @@ func cleanExpiredMessages() {
 			}
 
 			cutoff := time.Now().Unix() - int64(retention/time.Second)
-			deleted := deleteExpiredGroupMessages(inst, groupID, cutoff)
+			deleted := deleteExpiredGroupMessages(ctx, inst, groupID, cutoff)
 			if deleted > 0 {
 				totalDeleted += deleted
 				log.Printf("retention: deleted %d messages from group %q (instance %s)", deleted, groupID, inst.Config.Schema)
@@ -105,8 +112,9 @@ func cleanExpiredMessages() {
 
 // deleteOneRetentionBatch runs one bounded DELETE batch. Pulled out so the
 // per-iteration ctx can use `defer cancel()` and survive any future early
-// returns added inside the batch logic.
-func deleteOneRetentionBatch(inst *Instance, groupID string, cutoff int64) (rowsAffected int64, more bool, err error) {
+// returns added inside the batch logic. ctx is the service root passed
+// down from the cleaner — derives a per-batch dbOpTimeout from it.
+func deleteOneRetentionBatch(ctx context.Context, inst *Instance, groupID string, cutoff int64) (rowsAffected int64, more bool, err error) {
 	eventsTable := inst.Events.Schema.Prefix("events")
 	tagsTable := inst.Events.Schema.Prefix("event_tags")
 
@@ -128,10 +136,10 @@ func deleteOneRetentionBatch(inst *Instance, groupID string, cutoff int64) (rows
 	// CASCADE on event_tags foreign key handles tag cleanup.
 	deleteSQL := "DELETE FROM " + eventsTable + " WHERE id IN (" + subSQL + ")"
 
-	ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+	subctx, cancel := context.WithTimeout(ctx, dbOpTimeout)
 	defer cancel()
 
-	result, err := GetDb().ExecContext(ctx, deleteSQL, subArgs...)
+	result, err := GetDb().ExecContext(subctx, deleteSQL, subArgs...)
 	if err != nil {
 		return 0, false, fmt.Errorf("exec delete: %w", err)
 	}
@@ -143,10 +151,10 @@ func deleteOneRetentionBatch(inst *Instance, groupID string, cutoff int64) (rows
 	return rowsAffected, rowsAffected >= retentionDeleteBatchSize, nil
 }
 
-func deleteExpiredGroupMessages(inst *Instance, groupID string, cutoff int64) int64 {
+func deleteExpiredGroupMessages(ctx context.Context, inst *Instance, groupID string, cutoff int64) int64 {
 	var totalDeleted int64
 	for {
-		rows, more, err := deleteOneRetentionBatch(inst, groupID, cutoff)
+		rows, more, err := deleteOneRetentionBatch(ctx, inst, groupID, cutoff)
 		if err != nil {
 			log.Printf("retention: %s for group %q", err, groupID)
 			return totalDeleted

--- a/zooid/retention.go
+++ b/zooid/retention.go
@@ -1,6 +1,7 @@
 package zooid
 
 import (
+	"context"
 	"log"
 	"sync"
 	"time"
@@ -126,7 +127,9 @@ func deleteExpiredGroupMessages(inst *Instance, groupID string, cutoff int64) in
 		// CASCADE on event_tags foreign key handles tag cleanup.
 		deleteSQL := "DELETE FROM " + eventsTable + " WHERE id IN (" + subSQL + ")"
 
-		result, err := GetDb().Exec(deleteSQL, subArgs...)
+		ctx, cancel := context.WithTimeout(context.Background(), dbOpTimeout)
+		result, err := GetDb().ExecContext(ctx, deleteSQL, subArgs...)
+		cancel()
 		if err != nil {
 			log.Printf("retention: failed to delete messages for group %q: %v", groupID, err)
 			return totalDeleted


### PR DESCRIPTION
Fixes #18.

## Summary

Follow-up to #19. The original fix only bounded `BeginTx` in `SaveEvent`/`ReplaceEvent`; pprof on `sha-67fb306` ([comment](https://github.com/unicitynetwork/unicity-relay/issues/18#issuecomment-4363465233)) caught ~84% of parked goroutines waiting in **`QueryEvents.queryEventsWith` at `events.go:169`** — a plain `(*DB).Query()` with no context, parked forever on the pool wait queue. The leak just rerouted through the read path.

This PR audits every runtime DB call site in `zooid/` and switches to the `*Context` variant with a per-call `context.WithTimeout(context.Background(), dbOpTimeout)` (single `30s` constant):

- `queryEventsWith` — `Query` → `QueryContext` (the dominant leak path)
- `deleteEventWith` — `Exec` → `ExecContext`
- `saveEventWith` — three inner `Exec`s (event row + tag batches) → `ExecContext`
- `CountEvents` — `QueryRow` → `QueryRowContext`
- `kv.go` `Get`/`Set` — `Query`/`Exec` → `QueryContext`/`ExecContext`
- `metrics.go` reltuples estimate + group-message counts — same
- `retention.go` per-batch `DELETE` — `Exec` → `ExecContext`

Outer `saveEventTxTimeout` (30s) and `replaceEventTotalBudget` (60s) stay — they bound the whole tx including SSI retries. Startup-only paths (schema init, FTS init, migrations, KV init) are deliberately left unbounded; they run before the pool is in use.

## Regression test

`TestEventStore_QueryEvents_PoolSaturation_Issue18` mirrors the existing `ReplaceEvent` test for the read path: caps the pool at 1 connection, parks it in a held tx, fires 50 concurrent `QueryEvents` iterations. Refactored the saturation harness into `withSaturatedPool` so both tests share it.

**Verified pre-fix:** temporarily restored `Query()` (no context) in `queryEventsWith` and ran the test — `only 0/50 QueryEvents iterators terminated within 1.5s`. With the fix it passes in ~340ms.

## Test plan

- [x] `go test ./zooid/ ./cmd/relay/` passes
- [x] New `TestEventStore_QueryEvents_PoolSaturation_Issue18` catches the regression (verified empirically against reverted fix)
- [x] Existing `TestEventStore_ReplaceEvent_PoolSaturation_Issue18` still passes
- [ ] Deploy to `sphere-zooid-relay-eu`; on the next pprof dump under load, expect the `QueryEvents`/`(*DB).conn` stack to drop from ~4000 to near zero