### PR TITLE
groups: warm membership/role caches from kind-39001/39002 snapshots

### DIFF
--- a/zooid/cache_test.go
+++ b/zooid/cache_test.go
@@ -361,8 +361,22 @@ func TestGroupMembershipCache_WarmUp(t *testing.T) {
 	pk1 := nostr.Generate().Public()
 	pk2 := nostr.Generate().Public()
 
-	groups.AddMember("grp1", pk1)
-	groups.AddMember("grp1", pk2)
+	// Persist a kind-39002 (members snapshot) — that's what WarmCaches
+	// reads (issue #25). In production this snapshot is emitted by the
+	// relay's own pipeline after AddMember; here we write it directly so
+	// the test isolates the warm-up read path.
+	snapshot := nostr.Event{
+		Kind:      nostr.KindSimpleGroupMembers,
+		CreatedAt: nostr.Now(),
+		Tags: nostr.Tags{
+			{"d", "grp1"},
+			{"p", pk1.Hex()},
+			{"p", pk2.Hex()},
+		},
+	}
+	if err := groups.Events.SignAndStoreEvent(&snapshot, false); err != nil {
+		t.Fatalf("save members snapshot: %v", err)
+	}
 
 	// Create fresh store and warm
 	groups2 := &GroupStore{
@@ -576,21 +590,37 @@ func TestRoleCache_ClearOnRemove(t *testing.T) {
 	}
 }
 
-func TestRoleCache_WarmUpFromPutUserEvents(t *testing.T) {
+// TestRoleCache_WarmUpFromAdminsSnapshot — was
+// TestRoleCache_WarmUpFromPutUserEvents. WarmCaches now reads the
+// kind-39001 admins snapshot (one per group) instead of replaying
+// kind-9000 put-user events; the role-position semantics on the p-tag
+// are the same. Issue #25.
+func TestRoleCache_WarmUpFromAdminsSnapshot(t *testing.T) {
 	groups, _ := createTestGroupStore()
 
 	pk := nostr.Generate().Public()
 
-	// Store a put-user event with writer role (p tag has role at position 2+)
-	putEvent := nostr.Event{
-		Kind:      nostr.KindSimpleGroupPutUser,
+	// kind-39001 admins snapshot: p-tag positions 2+ are roles per NIP-29.
+	adminsSnapshot := nostr.Event{
+		Kind:      nostr.KindSimpleGroupAdmins,
 		CreatedAt: nostr.Now(),
 		Tags: nostr.Tags{
+			{"d", "rolegrp"},
 			{"p", pk.Hex(), "writer"},
-			{"h", "rolegrp"},
 		},
 	}
-	groups.Events.SignAndStoreEvent(&putEvent, false)
+	groups.Events.SignAndStoreEvent(&adminsSnapshot, false)
+
+	// And the corresponding members snapshot — admins are also members.
+	membersSnapshot := nostr.Event{
+		Kind:      nostr.KindSimpleGroupMembers,
+		CreatedAt: nostr.Now(),
+		Tags: nostr.Tags{
+			{"d", "rolegrp"},
+			{"p", pk.Hex()},
+		},
+	}
+	groups.Events.SignAndStoreEvent(&membersSnapshot, false)
 
 	// Fresh store and warm
 	groups2 := &GroupStore{
@@ -601,39 +631,56 @@ func TestRoleCache_WarmUpFromPutUserEvents(t *testing.T) {
 	groups2.WarmCaches()
 
 	if !groups2.HasRole("rolegrp", pk, "writer") {
-		t.Error("HasRole should return true after WarmCaches with put-user role")
+		t.Error("HasRole should return true after WarmCaches with admins-snapshot role")
 	}
 	if !groups2.IsMember("rolegrp", pk) {
 		t.Error("IsMember should also return true")
 	}
 }
 
-func TestRoleCache_WarmUpRoleReplacement(t *testing.T) {
+// TestRoleCache_WarmUp_NewerSnapshotWins replaces the previous
+// TestRoleCache_WarmUpRoleReplacement: now that WarmCaches reads
+// kind-39001/39002 snapshots and "first wins per group" by created_at
+// DESC, the regression we want to lock in is that a stale leftover
+// snapshot (e.g. one that wasn't yet replaced by the addressable-
+// replaceable dedup) does not stomp the current state. Issue #25.
+func TestRoleCache_WarmUp_NewerSnapshotWins(t *testing.T) {
 	groups, _ := createTestGroupStore()
 
 	pk := nostr.Generate().Public()
 
-	// First put-user with writer role
-	putEvent1 := nostr.Event{
-		Kind:      nostr.KindSimpleGroupPutUser,
+	// Older 39001: pk had the writer role.
+	oldAdmins := nostr.Event{
+		Kind:      nostr.KindSimpleGroupAdmins,
 		CreatedAt: nostr.Timestamp(1000),
 		Tags: nostr.Tags{
+			{"d", "replacegrp"},
 			{"p", pk.Hex(), "writer"},
-			{"h", "replacegrp"},
 		},
 	}
-	groups.Events.SignAndStoreEvent(&putEvent1, false)
+	groups.Events.SignAndStoreEvent(&oldAdmins, false)
 
-	// Second put-user without writer role (should replace)
-	putEvent2 := nostr.Event{
-		Kind:      nostr.KindSimpleGroupPutUser,
+	// Newer 39001: pk no longer has any role (current state).
+	newAdmins := nostr.Event{
+		Kind:      nostr.KindSimpleGroupAdmins,
 		CreatedAt: nostr.Timestamp(2000),
 		Tags: nostr.Tags{
+			{"d", "replacegrp"},
 			{"p", pk.Hex()},
-			{"h", "replacegrp"},
 		},
 	}
-	groups.Events.SignAndStoreEvent(&putEvent2, false)
+	groups.Events.SignAndStoreEvent(&newAdmins, false)
+
+	// And the matching 39002 so pk is still a member.
+	members := nostr.Event{
+		Kind:      nostr.KindSimpleGroupMembers,
+		CreatedAt: nostr.Timestamp(2000),
+		Tags: nostr.Tags{
+			{"d", "replacegrp"},
+			{"p", pk.Hex()},
+		},
+	}
+	groups.Events.SignAndStoreEvent(&members, false)
 
 	// Fresh store and warm
 	groups2 := &GroupStore{
@@ -644,10 +691,10 @@ func TestRoleCache_WarmUpRoleReplacement(t *testing.T) {
 	groups2.WarmCaches()
 
 	if groups2.HasRole("replacegrp", pk, "writer") {
-		t.Error("HasRole should return false after role was replaced by later put-user")
+		t.Error("HasRole should be false: newer admins snapshot dropped the role, older snapshot must not stomp it")
 	}
 	if !groups2.IsMember("replacegrp", pk) {
-		t.Error("IsMember should still return true")
+		t.Error("IsMember should still return true from the members snapshot")
 	}
 }
 

--- a/zooid/cache_test.go
+++ b/zooid/cache_test.go
@@ -405,25 +405,19 @@ func TestGroupMembershipCache_AddRemove(t *testing.T) {
 
 	pk := nostr.Generate().Public()
 
+	// Mark grp2 as fully loaded for the test. Production sets this
+	// in OnEventSaved for kind-9007 (new group creation), but this
+	// artificial test bypasses that flow. Without the marker
+	// IsMember falls back to the DB, which can't deterministically
+	// order Add+Remove events that share a second's created_at.
+	groups.membershipFullyLoaded.Store("grp2", struct{}{})
+
 	groups.AddMember("grp2", pk)
-	// Production calls ScheduleMembersListUpdate after AddMember (via
-	// OnEventSaved). UpdateMembersList writes a fresh 39002 from the
-	// current cache state and marks the group as fully loaded so
-	// IsMember consults the cache instead of falling back to the DB.
-	// Without this, AddMember + RemoveMember within the same second
-	// share a created_at and the DB-fallback path can't determine
-	// the latest event from the data alone.
-	if err := groups.UpdateMembersList("grp2"); err != nil {
-		t.Fatalf("UpdateMembersList: %v", err)
-	}
 	if !groups.IsMember("grp2", pk) {
 		t.Error("IsMember should return true after AddMember")
 	}
 
 	groups.RemoveMember("grp2", pk)
-	if err := groups.UpdateMembersList("grp2"); err != nil {
-		t.Fatalf("UpdateMembersList: %v", err)
-	}
 	if groups.IsMember("grp2", pk) {
 		t.Error("IsMember should return false after RemoveMember")
 	}

--- a/zooid/cache_test.go
+++ b/zooid/cache_test.go
@@ -406,11 +406,24 @@ func TestGroupMembershipCache_AddRemove(t *testing.T) {
 	pk := nostr.Generate().Public()
 
 	groups.AddMember("grp2", pk)
+	// Production calls ScheduleMembersListUpdate after AddMember (via
+	// OnEventSaved). UpdateMembersList writes a fresh 39002 from the
+	// current cache state and marks the group as fully loaded so
+	// IsMember consults the cache instead of falling back to the DB.
+	// Without this, AddMember + RemoveMember within the same second
+	// share a created_at and the DB-fallback path can't determine
+	// the latest event from the data alone.
+	if err := groups.UpdateMembersList("grp2"); err != nil {
+		t.Fatalf("UpdateMembersList: %v", err)
+	}
 	if !groups.IsMember("grp2", pk) {
 		t.Error("IsMember should return true after AddMember")
 	}
 
 	groups.RemoveMember("grp2", pk)
+	if err := groups.UpdateMembersList("grp2"); err != nil {
+		t.Fatalf("UpdateMembersList: %v", err)
+	}
 	if groups.IsMember("grp2", pk) {
 		t.Error("IsMember should return false after RemoveMember")
 	}
@@ -633,35 +646,64 @@ func TestRoleCache_WarmUpFromMembersSnapshot(t *testing.T) {
 // TestRoleCache_WarmUpRoleReplacement: now that WarmCaches reads the
 // kind-39002 members snapshot and "first wins per group" by
 // created_at DESC, the regression we want to lock in is that a stale
-// leftover snapshot (e.g. one that wasn't yet replaced by the
-// addressable-replaceable dedup) does not stomp the current state.
-// Issue #25.
+// leftover snapshot does not stomp the current state.
+//
+// IMPORTANT: We bypass SignAndStoreEvent because for addressable-
+// replaceable kinds (39002 included) it routes through ReplaceEvent,
+// which deletes any older row at write time. With both rows
+// auto-deduped the test would pass trivially without ever exercising
+// the WarmCaches first-wins logic. Signing locally and calling the
+// low-level SaveEvent forces both rows to coexist in the DB, which is
+// the actual concurrent-write race the warm-up code defends against.
+// Issue #25 follow-up review.
 func TestRoleCache_WarmUp_NewerSnapshotWins(t *testing.T) {
 	groups, _ := createTestGroupStore()
 
 	pk := nostr.Generate().Public()
+	sec := groups.Config.secret
 
 	// Older 39002: pk had the writer role.
 	oldMembers := nostr.Event{
 		Kind:      nostr.KindSimpleGroupMembers,
 		CreatedAt: nostr.Timestamp(1000),
+		PubKey:    sec.Public(),
 		Tags: nostr.Tags{
 			{"d", "replacegrp"},
 			{"p", pk.Hex(), "writer"},
 		},
 	}
-	groups.Events.SignAndStoreEvent(&oldMembers, false)
+	oldMembers.Sign(sec)
+	if err := groups.Events.SaveEvent(oldMembers); err != nil {
+		t.Fatalf("SaveEvent older snapshot: %v", err)
+	}
 
 	// Newer 39002: pk no longer has any role, but is still a member.
 	newMembers := nostr.Event{
 		Kind:      nostr.KindSimpleGroupMembers,
 		CreatedAt: nostr.Timestamp(2000),
+		PubKey:    sec.Public(),
 		Tags: nostr.Tags{
 			{"d", "replacegrp"},
 			{"p", pk.Hex()},
 		},
 	}
-	groups.Events.SignAndStoreEvent(&newMembers, false)
+	newMembers.Sign(sec)
+	if err := groups.Events.SaveEvent(newMembers); err != nil {
+		t.Fatalf("SaveEvent newer snapshot: %v", err)
+	}
+
+	// Sanity: both events must coexist in the DB. Otherwise the test
+	// is trivially passing because only the newer snapshot remains.
+	count := 0
+	for range groups.Events.QueryEvents(nostr.Filter{
+		Kinds: []nostr.Kind{nostr.KindSimpleGroupMembers},
+		Tags:  nostr.TagMap{"d": []string{"replacegrp"}},
+	}, 0) {
+		count++
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 39002 rows for replacegrp (test depends on coexistence), got %d", count)
+	}
 
 	// Fresh store and warm
 	groups2 := &GroupStore{
@@ -875,6 +917,10 @@ func TestGroupMembershipCache_DeleteClearsAll(t *testing.T) {
 	ms.mu.Lock()
 	ms.members[pk] = struct{}{}
 	ms.mu.Unlock()
+	// Mark fully loaded so IsMember trusts the cache directly (per
+	// the per-group fully-loaded gating). Otherwise IsMember would
+	// fall back to the DB and miss this directly-populated entry.
+	groups.membershipFullyLoaded.Store("delall", struct{}{})
 	groups.creatorCache.Store("delall", pk)
 
 	// Verify pre-conditions

--- a/zooid/cache_test.go
+++ b/zooid/cache_test.go
@@ -408,8 +408,11 @@ func TestGroupMembershipCache_AddRemove(t *testing.T) {
 	// Mark grp2 as fully loaded for the test. Production sets this
 	// in OnEventSaved for kind-9007 (new group creation), but this
 	// artificial test bypasses that flow. Without the marker
-	// IsMember falls back to the DB, which can't deterministically
-	// order Add+Remove events that share a second's created_at.
+	// IsMember would fall back to the DB-query path, which would
+	// still resolve correctly (the DB-fallback uses the
+	// `(created_at, id)` tiebreak now) but tying the assertion to
+	// the cache path is more direct: this test is about Add/Remove
+	// updating the in-memory cache, not the DB-fallback semantics.
 	groups.membershipFullyLoaded.Store("grp2", struct{}{})
 
 	groups.AddMember("grp2", pk)

--- a/zooid/cache_test.go
+++ b/zooid/cache_test.go
@@ -590,34 +590,25 @@ func TestRoleCache_ClearOnRemove(t *testing.T) {
 	}
 }
 
-// TestRoleCache_WarmUpFromAdminsSnapshot — was
-// TestRoleCache_WarmUpFromPutUserEvents. WarmCaches now reads the
-// kind-39001 admins snapshot (one per group) instead of replaying
-// kind-9000 put-user events; the role-position semantics on the p-tag
-// are the same. Issue #25.
-func TestRoleCache_WarmUpFromAdminsSnapshot(t *testing.T) {
+// TestRoleCache_WarmUpFromMembersSnapshot — was
+// TestRoleCache_WarmUpFromPutUserEvents. WarmCaches now reads roles
+// out of kind-39002 (members) p-tag positions 2+, matching how
+// UpdateMembersList actually emits them. UpdateAdminsList (kind-39001)
+// emits only `{"p", pubkey}` with no role positions, so 39001 is not
+// a source of role data. Issue #25.
+func TestRoleCache_WarmUpFromMembersSnapshot(t *testing.T) {
 	groups, _ := createTestGroupStore()
 
 	pk := nostr.Generate().Public()
 
-	// kind-39001 admins snapshot: p-tag positions 2+ are roles per NIP-29.
-	adminsSnapshot := nostr.Event{
-		Kind:      nostr.KindSimpleGroupAdmins,
-		CreatedAt: nostr.Now(),
-		Tags: nostr.Tags{
-			{"d", "rolegrp"},
-			{"p", pk.Hex(), "writer"},
-		},
-	}
-	groups.Events.SignAndStoreEvent(&adminsSnapshot, false)
-
-	// And the corresponding members snapshot — admins are also members.
+	// kind-39002 members snapshot: per-member p-tag carries roles at
+	// positions 2+, exactly the shape UpdateMembersList writes.
 	membersSnapshot := nostr.Event{
 		Kind:      nostr.KindSimpleGroupMembers,
 		CreatedAt: nostr.Now(),
 		Tags: nostr.Tags{
 			{"d", "rolegrp"},
-			{"p", pk.Hex()},
+			{"p", pk.Hex(), "writer"},
 		},
 	}
 	groups.Events.SignAndStoreEvent(&membersSnapshot, false)
@@ -631,7 +622,7 @@ func TestRoleCache_WarmUpFromAdminsSnapshot(t *testing.T) {
 	groups2.WarmCaches()
 
 	if !groups2.HasRole("rolegrp", pk, "writer") {
-		t.Error("HasRole should return true after WarmCaches with admins-snapshot role")
+		t.Error("HasRole should return true after WarmCaches with members-snapshot role")
 	}
 	if !groups2.IsMember("rolegrp", pk) {
 		t.Error("IsMember should also return true")
@@ -639,40 +630,30 @@ func TestRoleCache_WarmUpFromAdminsSnapshot(t *testing.T) {
 }
 
 // TestRoleCache_WarmUp_NewerSnapshotWins replaces the previous
-// TestRoleCache_WarmUpRoleReplacement: now that WarmCaches reads
-// kind-39001/39002 snapshots and "first wins per group" by created_at
-// DESC, the regression we want to lock in is that a stale leftover
-// snapshot (e.g. one that wasn't yet replaced by the addressable-
-// replaceable dedup) does not stomp the current state. Issue #25.
+// TestRoleCache_WarmUpRoleReplacement: now that WarmCaches reads the
+// kind-39002 members snapshot and "first wins per group" by
+// created_at DESC, the regression we want to lock in is that a stale
+// leftover snapshot (e.g. one that wasn't yet replaced by the
+// addressable-replaceable dedup) does not stomp the current state.
+// Issue #25.
 func TestRoleCache_WarmUp_NewerSnapshotWins(t *testing.T) {
 	groups, _ := createTestGroupStore()
 
 	pk := nostr.Generate().Public()
 
-	// Older 39001: pk had the writer role.
-	oldAdmins := nostr.Event{
-		Kind:      nostr.KindSimpleGroupAdmins,
+	// Older 39002: pk had the writer role.
+	oldMembers := nostr.Event{
+		Kind:      nostr.KindSimpleGroupMembers,
 		CreatedAt: nostr.Timestamp(1000),
 		Tags: nostr.Tags{
 			{"d", "replacegrp"},
 			{"p", pk.Hex(), "writer"},
 		},
 	}
-	groups.Events.SignAndStoreEvent(&oldAdmins, false)
+	groups.Events.SignAndStoreEvent(&oldMembers, false)
 
-	// Newer 39001: pk no longer has any role (current state).
-	newAdmins := nostr.Event{
-		Kind:      nostr.KindSimpleGroupAdmins,
-		CreatedAt: nostr.Timestamp(2000),
-		Tags: nostr.Tags{
-			{"d", "replacegrp"},
-			{"p", pk.Hex()},
-		},
-	}
-	groups.Events.SignAndStoreEvent(&newAdmins, false)
-
-	// And the matching 39002 so pk is still a member.
-	members := nostr.Event{
+	// Newer 39002: pk no longer has any role, but is still a member.
+	newMembers := nostr.Event{
 		Kind:      nostr.KindSimpleGroupMembers,
 		CreatedAt: nostr.Timestamp(2000),
 		Tags: nostr.Tags{
@@ -680,7 +661,7 @@ func TestRoleCache_WarmUp_NewerSnapshotWins(t *testing.T) {
 			{"p", pk.Hex()},
 		},
 	}
-	groups.Events.SignAndStoreEvent(&members, false)
+	groups.Events.SignAndStoreEvent(&newMembers, false)
 
 	// Fresh store and warm
 	groups2 := &GroupStore{
@@ -691,7 +672,7 @@ func TestRoleCache_WarmUp_NewerSnapshotWins(t *testing.T) {
 	groups2.WarmCaches()
 
 	if groups2.HasRole("replacegrp", pk, "writer") {
-		t.Error("HasRole should be false: newer admins snapshot dropped the role, older snapshot must not stomp it")
+		t.Error("HasRole should be false: newer members snapshot dropped the role, older snapshot must not stomp it")
 	}
 	if !groups2.IsMember("replacegrp", pk) {
 		t.Error("IsMember should still return true from the members snapshot")

--- a/zooid/groups.go
+++ b/zooid/groups.go
@@ -1,6 +1,7 @@
 package zooid
 
 import (
+	"bytes"
 	"encoding/json"
 	"log"
 	"sort"
@@ -159,8 +160,8 @@ func (g *GroupStore) WarmCaches() {
 		}
 	}
 
-	// Load group memberships from the kind-39002 (members) and kind-39001
-	// (admins, with roles) snapshot events that the relay maintains.
+	// Load group memberships from the kind-39002 (members) snapshot
+	// and the kind-39001 (admins) snapshot the relay maintains.
 	//
 	// Until 2026-05 this loop replayed the full kind-9000/9001 put/remove
 	// log, which on production with 50k members had grown to 90k+ events.
@@ -170,24 +171,35 @@ func (g *GroupStore) WarmCaches() {
 	// real members. Issue #25.
 	//
 	// Reading snapshots is O(groups), not O(membership_events). One 39002
-	// per group carries the full current member set; one 39001 carries the
-	// admins with roles. Lag window: any change made between the last
-	// snapshot emission and the restart is missed by this rebuild — the
-	// live event handler in groups.go updates the cache on each new
-	// kind-9000/9001 going forward, so the gap closes naturally as those
-	// events arrive.
-	// QueryEvents returns events ordered by created_at DESC, so the first
-	// event we see per group is the newest. NIP-29 39001/39002 are
-	// addressable-replaceable keyed by d-tag; the relay normally keeps
-	// only one per group. We still defend against duplicates here so a
-	// stale leftover doesn't stomp the current state.
+	// per group carries the full current member set; roles ride on each
+	// p-tag at positions 2+ (UpdateMembersList writes them this way).
+	// kind-39001 carries only `{"p", pubkey}` per admin — no role
+	// positions — and is read here only as a defensive safety net so an
+	// admin missing from a stale 39002 still surfaces as a member.
 	//
-	// In this codebase the **roles live on kind-39002**, not 39001 —
-	// see UpdateMembersList: the per-member p-tag is
-	// `{"p", pubkey, role1, role2, ...}`. UpdateAdminsList emits
-	// `{"p", pubkey}` only. So the members snapshot drives both the
-	// membership and the role caches.
-	seenMembers := make(map[string]struct{})
+	// Lag window: any change made between the last snapshot emission for
+	// a group and a restart is missed by this rebuild. The live event
+	// handler in groups.go updates the cache on each new kind-9000/9001
+	// going forward, so the gap closes naturally as those events arrive.
+	// QueryEvents returns events ordered by created_at DESC. We
+	// dedupe per group with an explicit (created_at, id) tiebreaker
+	// because two concurrent ReplaceEvent calls can race past the
+	// `<=` dedup check in events.go and leave two rows with the
+	// same created_at — DESC alone is unstable in that case. id
+	// is the canonical event hash, so lexicographic compare gives
+	// deterministic ordering.
+	type snapshotKey struct {
+		createdAt nostr.Timestamp
+		id        nostr.ID
+	}
+	newer := func(a, b snapshotKey) bool {
+		if a.createdAt != b.createdAt {
+			return a.createdAt > b.createdAt
+		}
+		return bytes.Compare(a.id[:], b.id[:]) > 0
+	}
+
+	seenMembers := make(map[string]snapshotKey)
 	for event := range g.Events.QueryEvents(nostr.Filter{
 		Kinds: []nostr.Kind{nostr.KindSimpleGroupMembers},
 	}, 0) {
@@ -195,14 +207,19 @@ func (g *GroupStore) WarmCaches() {
 		if h == "" {
 			continue
 		}
-		if _, dup := seenMembers[h]; dup {
+		k := snapshotKey{createdAt: event.CreatedAt, id: event.ID}
+		if existing, ok := seenMembers[h]; ok && !newer(k, existing) {
 			continue
 		}
-		seenMembers[h] = struct{}{}
+		seenMembers[h] = k
 		ms := g.getOrCreateMemberSet(h)
 		rs := g.getOrCreateRoleSet(h)
 		ms.mu.Lock()
 		rs.mu.Lock()
+		// Replace state — the old snapshot might have stale members
+		// or stale role assignments we need to drop.
+		ms.members = make(map[nostr.PubKey]struct{}, len(event.Tags))
+		rs.roles = make(map[nostr.PubKey]map[string]struct{})
 		for tag := range event.Tags.FindAll("p") {
 			if len(tag) < 2 {
 				continue
@@ -225,10 +242,15 @@ func (g *GroupStore) WarmCaches() {
 	}
 
 	// Belt-and-suspenders: admins per NIP-29 are implicitly members.
-	// If a 39001 lists a pubkey that's missing from a possibly-stale
-	// 39002 snapshot, surface them as a member so they don't get
+	// If a 39001 lists a pubkey that's missing from a stale 39002
+	// snapshot, surface them as a member so they don't get
 	// false-rejected by IsMember after a restart.
-	seenAdmins := make(map[string]struct{})
+	//
+	// Only honor 39001 admins as members when this 39001 is newer
+	// than the 39002 we loaded for the same group. If 39002 is newer,
+	// it's authoritative — an admin who was removed (and so dropped
+	// from the newer 39002) must not get re-added by an older 39001.
+	seenAdmins := make(map[string]snapshotKey)
 	for event := range g.Events.QueryEvents(nostr.Filter{
 		Kinds: []nostr.Kind{nostr.KindSimpleGroupAdmins},
 	}, 0) {
@@ -236,10 +258,21 @@ func (g *GroupStore) WarmCaches() {
 		if h == "" {
 			continue
 		}
-		if _, dup := seenAdmins[h]; dup {
+		k := snapshotKey{createdAt: event.CreatedAt, id: event.ID}
+		if existing, ok := seenAdmins[h]; ok && !newer(k, existing) {
 			continue
 		}
-		seenAdmins[h] = struct{}{}
+		seenAdmins[h] = k
+		// Only skip when the 39002 we already loaded is STRICTLY
+		// newer than this 39001. Equal created_at falls through —
+		// the two snapshots are typically debounced together and
+		// reflect the same moment, and we can't claim 39002 is
+		// authoritative just because of an arbitrary id tiebreak.
+		// 39001 newer also falls through (its admin promotions
+		// haven't propagated to 39002 yet).
+		if memberKey, hasMembers := seenMembers[h]; hasMembers && k.createdAt < memberKey.createdAt {
+			continue
+		}
 		ms := g.getOrCreateMemberSet(h)
 		ms.mu.Lock()
 		for tag := range event.Tags.FindAll("p") {
@@ -261,6 +294,26 @@ func (g *GroupStore) WarmCaches() {
 		if err := g.UpdateMetadata(event); err != nil {
 			log.Printf("Failed to regenerate metadata for group %q: %v", h, err)
 		}
+	}
+
+	// Heuristic warm-up failure detection. The QueryEvents iter.Seq
+	// surface can't return errors — queryEventsWith logs and stops on
+	// timeout but the consumer just sees a short sequence. If the
+	// metadata cache shows we have groups but the members/admins
+	// snapshot reads came back with no data at all, the most likely
+	// explanation is a query timeout under DB pressure (the very
+	// scenario that motivated issue #25 in the first place). Stay in
+	// pre-warm mode so IsMember falls back to its DB query path —
+	// slow per-call but correct, vs. setting cachesWarmed=true and
+	// silently false-rejecting members.
+	metadataCount := 0
+	g.metadataCache.Range(func(_, _ any) bool {
+		metadataCount++
+		return true
+	})
+	if metadataCount > 0 && len(seenMembers) == 0 && len(seenAdmins) == 0 {
+		log.Printf("WarmCaches: %d groups in metadata but 0 members/admins snapshot events read — staying in pre-warm mode (IsMember will fall back to DB)", metadataCount)
+		return
 	}
 
 	g.cachesWarmed = true

--- a/zooid/groups.go
+++ b/zooid/groups.go
@@ -246,10 +246,10 @@ func (g *GroupStore) WarmCaches() {
 	// snapshot, surface them as a member so they don't get
 	// false-rejected by IsMember after a restart.
 	//
-	// Only honor 39001 admins as members when this 39001 is newer
-	// than the 39002 we loaded for the same group. If 39002 is newer,
-	// it's authoritative — an admin who was removed (and so dropped
-	// from the newer 39002) must not get re-added by an older 39001.
+	// Skip 39001-driven adds when the 39002 we loaded for the same
+	// group is STRICTLY newer — an admin removed by the newer 39002
+	// must not get re-added by an older 39001. Equal created_at
+	// falls through (apply) — see the per-iteration comment below.
 	seenAdmins := make(map[string]snapshotKey)
 	for event := range g.Events.QueryEvents(nostr.Filter{
 		Kinds: []nostr.Kind{nostr.KindSimpleGroupAdmins},

--- a/zooid/groups.go
+++ b/zooid/groups.go
@@ -762,18 +762,25 @@ func (g *GroupStore) UpdateMembersList(h string) error {
 		Tags:      tags,
 	}
 
-	if err := g.Events.SignAndStoreEvent(&event, true); err != nil {
-		return err
-	}
-	// We just published a fresh 39002 derived from the current
-	// in-memory state, so for this group the cache IS authoritative
-	// from this point on. Mark fully loaded — IsMember can now use
-	// the cache for h instead of falling back to the DB. This also
-	// handles new groups created post-WarmCaches (CreateGroup runs
-	// AddMember + ScheduleMembersListUpdate, so by the time the
-	// snapshot lands the cache is current).
-	g.membershipFullyLoaded.Store(h, struct{}{})
-	return nil
+	// NB: we deliberately do NOT mark membershipFullyLoaded here.
+	// UpdateMembersList just rewrites the on-disk 39002 from
+	// whatever the in-memory cache currently holds. If the cache
+	// was authoritative going in (fullyLoaded was already set), the
+	// rewrite is a fresh, correct snapshot — and the marker stays
+	// set. If the cache was NOT authoritative (e.g. WarmCaches
+	// missed this group's 39002 → fullyLoaded=false), promoting it
+	// here would publish a partial member list AND mark the cache
+	// authoritative, silently false-rejecting real members on
+	// future IsMember calls and persisting the wrong snapshot for
+	// the next restart's WarmCaches to consume. Issue #25 review.
+	//
+	// Authoritative-state ownership lives elsewhere:
+	//  - WarmCaches sets the marker after applying a 39002 read.
+	//  - OnEventSaved for kind-9007 (new group creation) sets it
+	//    explicitly before the first AddMember/UpdateMembersList,
+	//    because a brand-new group has no pre-existing members and
+	//    the cache trivially reflects full membership.
+	return g.Events.SignAndStoreEvent(&event, true)
 }
 
 // ScheduleMembersListUpdate publishes a fresh kind-39002 for h, debounced by

--- a/zooid/groups.go
+++ b/zooid/groups.go
@@ -181,6 +181,12 @@ func (g *GroupStore) WarmCaches() {
 	// addressable-replaceable keyed by d-tag; the relay normally keeps
 	// only one per group. We still defend against duplicates here so a
 	// stale leftover doesn't stomp the current state.
+	//
+	// In this codebase the **roles live on kind-39002**, not 39001 —
+	// see UpdateMembersList: the per-member p-tag is
+	// `{"p", pubkey, role1, role2, ...}`. UpdateAdminsList emits
+	// `{"p", pubkey}` only. So the members snapshot drives both the
+	// membership and the role caches.
 	seenMembers := make(map[string]struct{})
 	for event := range g.Events.QueryEvents(nostr.Filter{
 		Kinds: []nostr.Kind{nostr.KindSimpleGroupMembers},
@@ -194,15 +200,34 @@ func (g *GroupStore) WarmCaches() {
 		}
 		seenMembers[h] = struct{}{}
 		ms := g.getOrCreateMemberSet(h)
+		rs := g.getOrCreateRoleSet(h)
 		ms.mu.Lock()
+		rs.mu.Lock()
 		for tag := range event.Tags.FindAll("p") {
-			if pubkey, err := nostr.PubKeyFromHex(tag[1]); err == nil {
-				ms.members[pubkey] = struct{}{}
+			if len(tag) < 2 {
+				continue
+			}
+			pubkey, err := nostr.PubKeyFromHex(tag[1])
+			if err != nil {
+				continue
+			}
+			ms.members[pubkey] = struct{}{}
+			if len(tag) > 2 {
+				roles := make(map[string]struct{}, len(tag)-2)
+				for i := 2; i < len(tag); i++ {
+					roles[tag[i]] = struct{}{}
+				}
+				rs.roles[pubkey] = roles
 			}
 		}
+		rs.mu.Unlock()
 		ms.mu.Unlock()
 	}
 
+	// Belt-and-suspenders: admins per NIP-29 are implicitly members.
+	// If a 39001 lists a pubkey that's missing from a possibly-stale
+	// 39002 snapshot, surface them as a member so they don't get
+	// false-rejected by IsMember after a restart.
 	seenAdmins := make(map[string]struct{})
 	for event := range g.Events.QueryEvents(nostr.Filter{
 		Kinds: []nostr.Kind{nostr.KindSimpleGroupAdmins},
@@ -215,23 +240,17 @@ func (g *GroupStore) WarmCaches() {
 			continue
 		}
 		seenAdmins[h] = struct{}{}
-		rs := g.getOrCreateRoleSet(h)
-		rs.mu.Lock()
+		ms := g.getOrCreateMemberSet(h)
+		ms.mu.Lock()
 		for tag := range event.Tags.FindAll("p") {
-			pubkey, err := nostr.PubKeyFromHex(tag[1])
-			if err != nil {
+			if len(tag) < 2 {
 				continue
 			}
-			// p-tag positions 2+ are roles per NIP-29.
-			if len(tag) > 2 {
-				roles := make(map[string]struct{}, len(tag)-2)
-				for i := 2; i < len(tag); i++ {
-					roles[tag[i]] = struct{}{}
-				}
-				rs.roles[pubkey] = roles
+			if pubkey, err := nostr.PubKeyFromHex(tag[1]); err == nil {
+				ms.members[pubkey] = struct{}{}
 			}
 		}
-		rs.mu.Unlock()
+		ms.mu.Unlock()
 	}
 
 	// Self-heal: regenerate metadata for groups that have a creation event but

--- a/zooid/groups.go
+++ b/zooid/groups.go
@@ -159,45 +159,79 @@ func (g *GroupStore) WarmCaches() {
 		}
 	}
 
-	// Load all group memberships
-	memberFilter := nostr.Filter{
-		Kinds: []nostr.Kind{nostr.KindSimpleGroupPutUser, nostr.KindSimpleGroupRemoveUser},
-	}
-	// We need to process events oldest-first to replay the membership log correctly
-	allEvents := slices.Collect(g.Events.QueryEvents(memberFilter, 0))
-	for _, event := range Reversed(allEvents) {
-		h := GetGroupIDFromEvent(event)
+	// Load group memberships from the kind-39002 (members) and kind-39001
+	// (admins, with roles) snapshot events that the relay maintains.
+	//
+	// Until 2026-05 this loop replayed the full kind-9000/9001 put/remove
+	// log, which on production with 50k members had grown to 90k+ events.
+	// The replay had to fit in dbOpTimeout (30s) including JSON-tag parses;
+	// under any DB CPU pressure the iteration timed out partway, the slice
+	// was partial, the cache ended up partial, and IsMember false-rejected
+	// real members. Issue #25.
+	//
+	// Reading snapshots is O(groups), not O(membership_events). One 39002
+	// per group carries the full current member set; one 39001 carries the
+	// admins with roles. Lag window: any change made between the last
+	// snapshot emission and the restart is missed by this rebuild — the
+	// live event handler in groups.go updates the cache on each new
+	// kind-9000/9001 going forward, so the gap closes naturally as those
+	// events arrive.
+	// QueryEvents returns events ordered by created_at DESC, so the first
+	// event we see per group is the newest. NIP-29 39001/39002 are
+	// addressable-replaceable keyed by d-tag; the relay normally keeps
+	// only one per group. We still defend against duplicates here so a
+	// stale leftover doesn't stomp the current state.
+	seenMembers := make(map[string]struct{})
+	for event := range g.Events.QueryEvents(nostr.Filter{
+		Kinds: []nostr.Kind{nostr.KindSimpleGroupMembers},
+	}, 0) {
+		h := event.Tags.GetD()
 		if h == "" {
 			continue
 		}
+		if _, dup := seenMembers[h]; dup {
+			continue
+		}
+		seenMembers[h] = struct{}{}
+		ms := g.getOrCreateMemberSet(h)
+		ms.mu.Lock()
+		for tag := range event.Tags.FindAll("p") {
+			if pubkey, err := nostr.PubKeyFromHex(tag[1]); err == nil {
+				ms.members[pubkey] = struct{}{}
+			}
+		}
+		ms.mu.Unlock()
+	}
+
+	seenAdmins := make(map[string]struct{})
+	for event := range g.Events.QueryEvents(nostr.Filter{
+		Kinds: []nostr.Kind{nostr.KindSimpleGroupAdmins},
+	}, 0) {
+		h := event.Tags.GetD()
+		if h == "" {
+			continue
+		}
+		if _, dup := seenAdmins[h]; dup {
+			continue
+		}
+		seenAdmins[h] = struct{}{}
+		rs := g.getOrCreateRoleSet(h)
+		rs.mu.Lock()
 		for tag := range event.Tags.FindAll("p") {
 			pubkey, err := nostr.PubKeyFromHex(tag[1])
 			if err != nil {
 				continue
 			}
-			ms := g.getOrCreateMemberSet(h)
-			ms.mu.Lock()
-			if event.Kind == nostr.KindSimpleGroupPutUser {
-				ms.members[pubkey] = struct{}{}
-			} else {
-				delete(ms.members, pubkey)
-			}
-			ms.mu.Unlock()
-
-			// Track roles from put-user events (positions 2+ in the p tag)
-			rs := g.getOrCreateRoleSet(h)
-			rs.mu.Lock()
-			if event.Kind == nostr.KindSimpleGroupPutUser && len(tag) > 2 {
+			// p-tag positions 2+ are roles per NIP-29.
+			if len(tag) > 2 {
 				roles := make(map[string]struct{}, len(tag)-2)
 				for i := 2; i < len(tag); i++ {
 					roles[tag[i]] = struct{}{}
 				}
 				rs.roles[pubkey] = roles
-			} else {
-				delete(rs.roles, pubkey)
 			}
-			rs.mu.Unlock()
 		}
+		rs.mu.Unlock()
 	}
 
 	// Self-heal: regenerate metadata for groups that have a creation event but

--- a/zooid/groups.go
+++ b/zooid/groups.go
@@ -95,6 +95,15 @@ type GroupStore struct {
 	creatorCache    sync.Map // map[string]nostr.PubKey       (key = group h)
 	cachesWarmed    bool
 
+	// membershipFullyLoaded tracks groups for which WarmCaches
+	// successfully applied a kind-39002 snapshot — meaning the
+	// membershipCache holds the complete known member set for that
+	// group. IsMember consults this per group so a partial WarmCaches
+	// read (timeout mid-iteration → only some groups loaded) silently
+	// false-rejects nothing: groups not in this set fall back to the
+	// DB query path. Issue #25 follow-up review.
+	membershipFullyLoaded sync.Map // map[string]struct{} (key = group h)
+
 	// DebounceDelay coalesces rapid bursts of kind-39002 / kind-39000 rewrites
 	// for the same group into a single publish, scheduled DebounceDelay after
 	// the first scheduled trigger in a burst. NIP-29 requires republishing the
@@ -212,6 +221,11 @@ func (g *GroupStore) WarmCaches() {
 			continue
 		}
 		seenMembers[h] = k
+		// Mark this group's membership as fully loaded — IsMember
+		// consults this per-group flag and only treats the cache as
+		// authoritative when set, so a group whose 39002 didn't get
+		// read (partial scan, timeout, etc.) falls back to DB.
+		g.membershipFullyLoaded.Store(h, struct{}{})
 		ms := g.getOrCreateMemberSet(h)
 		rs := g.getOrCreateRoleSet(h)
 		ms.mu.Lock()
@@ -509,6 +523,7 @@ func (g *GroupStore) DeleteGroup(h string) {
 
 	g.metadataCache.Delete(h)
 	g.membershipCache.Delete(h)
+	g.membershipFullyLoaded.Delete(h)
 	g.roleCache.Delete(h)
 	g.creatorCache.Delete(h)
 }
@@ -604,7 +619,12 @@ func (g *GroupStore) RemoveMember(h string, pubkey nostr.PubKey) error {
 }
 
 func (g *GroupStore) IsMember(h string, pubkey nostr.PubKey) bool {
-	if g.cachesWarmed {
+	// Per-group authoritative check: only trust the cache if WarmCaches
+	// successfully loaded a kind-39002 snapshot for this group. If not
+	// (partial WarmCaches scan, group created post-restart with no
+	// snapshot yet, etc.), fall through to the DB query path. Issue
+	// #25 follow-up review.
+	if _, fullyLoaded := g.membershipFullyLoaded.Load(h); fullyLoaded {
 		if v, ok := g.membershipCache.Load(h); ok {
 			ms := v.(*memberSet)
 			ms.mu.RLock()
@@ -612,7 +632,9 @@ func (g *GroupStore) IsMember(h string, pubkey nostr.PubKey) bool {
 			ms.mu.RUnlock()
 			return found
 		}
-		return false
+		// Marked fully loaded but no cache entry — shouldn't happen
+		// because they're set together. Defensive: treat as unloaded
+		// and fall through.
 	}
 
 	filter := nostr.Filter{
@@ -623,17 +645,31 @@ func (g *GroupStore) IsMember(h string, pubkey nostr.PubKey) bool {
 		},
 	}
 
-	for event := range g.Events.QueryEvents(filter, 1) {
-		if event.Kind == nostr.KindSimpleGroupPutUser {
-			return true
+	// Walk all (typically very few) put/remove events for this
+	// (pubkey, group) pair and pick the strictly latest by
+	// (created_at, id). QueryEvents orders by created_at DESC but
+	// with no secondary tiebreak — when add+remove land in the same
+	// second (test rapid-fire, real bursts), `LIMIT 1` returns an
+	// arbitrary one and the membership decision flips run-to-run.
+	// id is the canonical event hash so bytes.Compare gives a
+	// deterministic, total tiebreak.
+	var latest nostr.Event
+	var have bool
+	for event := range g.Events.QueryEvents(filter, 0) {
+		if !have {
+			latest = event
+			have = true
+			continue
 		}
-
-		if event.Kind == nostr.KindSimpleGroupRemoveUser {
-			return false
+		if event.CreatedAt > latest.CreatedAt ||
+			(event.CreatedAt == latest.CreatedAt && bytes.Compare(event.ID[:], latest.ID[:]) > 0) {
+			latest = event
 		}
 	}
-
-	return false
+	if !have {
+		return false
+	}
+	return latest.Kind == nostr.KindSimpleGroupPutUser
 }
 
 func (g *GroupStore) GetMembers(h string) []nostr.PubKey {
@@ -726,7 +762,18 @@ func (g *GroupStore) UpdateMembersList(h string) error {
 		Tags:      tags,
 	}
 
-	return g.Events.SignAndStoreEvent(&event, true)
+	if err := g.Events.SignAndStoreEvent(&event, true); err != nil {
+		return err
+	}
+	// We just published a fresh 39002 derived from the current
+	// in-memory state, so for this group the cache IS authoritative
+	// from this point on. Mark fully loaded — IsMember can now use
+	// the cache for h instead of falling back to the DB. This also
+	// handles new groups created post-WarmCaches (CreateGroup runs
+	// AddMember + ScheduleMembersListUpdate, so by the time the
+	// snapshot lands the cache is current).
+	g.membershipFullyLoaded.Store(h, struct{}{})
+	return nil
 }
 
 // ScheduleMembersListUpdate publishes a fresh kind-39002 for h, debounced by

--- a/zooid/groups.go
+++ b/zooid/groups.go
@@ -186,10 +186,12 @@ func (g *GroupStore) WarmCaches() {
 	// positions — and is read here only as a defensive safety net so an
 	// admin missing from a stale 39002 still surfaces as a member.
 	//
-	// Lag window: any change made between the last snapshot emission for
-	// a group and a restart is missed by this rebuild. The live event
-	// handler in groups.go updates the cache on each new kind-9000/9001
-	// going forward, so the gap closes naturally as those events arrive.
+	// Lag window closure: after applying snapshots, we read the tail of
+	// the kind-9000/9001 log since the OLDEST snapshot's created_at and
+	// re-apply any per-group events the snapshot didn't cover. Without
+	// this, membership changes that happened after a group's last 39002
+	// emission but before the relay restart stay missing from the cache
+	// indefinitely (the live handler doesn't replay them on its own).
 	// QueryEvents returns events ordered by created_at DESC. We
 	// dedupe per group with an explicit (created_at, id) tiebreaker
 	// because two concurrent ReplaceEvent calls can race past the
@@ -298,6 +300,71 @@ func (g *GroupStore) WarmCaches() {
 			}
 		}
 		ms.mu.Unlock()
+	}
+
+	// Tail-of-log read: replay any kind-9000/9001 events the
+	// snapshots didn't cover (events emitted after a group's last
+	// 39002 but before this restart). Without this, those membership
+	// changes stay missing from the cache and IsMember would
+	// false-reject the affected members until a new 39002 happens to
+	// be emitted for that group on the next change.
+	//
+	// We bound the tail by `Since = oldest 39002 created_at across
+	// all loaded groups`, then per-event we apply the change ONLY if
+	// the event is strictly newer than that group's snapshot. So old
+	// events covered by their group's snapshot are skipped per-row,
+	// and groups without a snapshot are skipped entirely (their
+	// membership stays under DB-fallback via IsMember). This keeps
+	// the tail size proportional to time-since-newest-snapshot
+	// (typically seconds-to-minutes thanks to the debounced 39002
+	// emission pipeline), not to total membership history.
+	if len(seenMembers) > 0 {
+		oldest := nostr.Timestamp(0)
+		first := true
+		for _, k := range seenMembers {
+			if first || k.createdAt < oldest {
+				oldest = k.createdAt
+				first = false
+			}
+		}
+		// QueryEvents returns DESC; replaying put/remove DESC gives
+		// the wrong final state when an Add+Remove pair lands in
+		// the tail (the remove fires against an empty set, then the
+		// add re-introduces the user). Collect and reverse to
+		// process oldest-first.
+		tail := slices.Collect(g.Events.QueryEvents(nostr.Filter{
+			Kinds: []nostr.Kind{nostr.KindSimpleGroupPutUser, nostr.KindSimpleGroupRemoveUser},
+			Since: oldest,
+		}, 0))
+		for _, event := range Reversed(tail) {
+			h := GetGroupIDFromEvent(event)
+			if h == "" {
+				continue
+			}
+			snap, hasSnap := seenMembers[h]
+			if !hasSnap || event.CreatedAt <= snap.createdAt {
+				// No snapshot for this group → leave it for DB
+				// fallback. Or event already covered by snapshot.
+				continue
+			}
+			ms := g.getOrCreateMemberSet(h)
+			ms.mu.Lock()
+			for tag := range event.Tags.FindAll("p") {
+				if len(tag) < 2 {
+					continue
+				}
+				pubkey, err := nostr.PubKeyFromHex(tag[1])
+				if err != nil {
+					continue
+				}
+				if event.Kind == nostr.KindSimpleGroupPutUser {
+					ms.members[pubkey] = struct{}{}
+				} else {
+					delete(ms.members, pubkey)
+				}
+			}
+			ms.mu.Unlock()
+		}
 	}
 
 	// Self-heal: regenerate metadata for groups that have a creation event but

--- a/zooid/groups.go
+++ b/zooid/groups.go
@@ -342,13 +342,25 @@ func (g *GroupStore) WarmCaches() {
 				continue
 			}
 			snap, hasSnap := seenMembers[h]
-			if !hasSnap || event.CreatedAt <= snap.createdAt {
+			if !hasSnap {
 				// No snapshot for this group → leave it for DB
-				// fallback. Or event already covered by snapshot.
+				// fallback via IsMember.
+				continue
+			}
+			// Strictly-newer-than-snapshot via the same
+			// (created_at, id) tiebreak used elsewhere. nostr
+			// timestamps are second-resolution, so plain `<=`
+			// drops events emitted in the same second as the
+			// snapshot — and those are exactly the changes the
+			// snapshot pipeline's debounce makes most likely.
+			eventKey := snapshotKey{createdAt: event.CreatedAt, id: event.ID}
+			if !newer(eventKey, snap) {
 				continue
 			}
 			ms := g.getOrCreateMemberSet(h)
+			rs := g.getOrCreateRoleSet(h)
 			ms.mu.Lock()
+			rs.mu.Lock()
 			for tag := range event.Tags.FindAll("p") {
 				if len(tag) < 2 {
 					continue
@@ -359,10 +371,29 @@ func (g *GroupStore) WarmCaches() {
 				}
 				if event.Kind == nostr.KindSimpleGroupPutUser {
 					ms.members[pubkey] = struct{}{}
+					// PutUser carries roles at p-tag positions 2+
+					// (NIP-29). Apply them so a role
+					// granted/cleared post-snapshot doesn't get
+					// silently lost from rs.roles. AddMember
+					// (the cache-update path) clears roles on
+					// each call, so do the same here: replace
+					// the role set if positions 2+ exist, drop
+					// it otherwise.
+					if len(tag) > 2 {
+						roles := make(map[string]struct{}, len(tag)-2)
+						for i := 2; i < len(tag); i++ {
+							roles[tag[i]] = struct{}{}
+						}
+						rs.roles[pubkey] = roles
+					} else {
+						delete(rs.roles, pubkey)
+					}
 				} else {
 					delete(ms.members, pubkey)
+					delete(rs.roles, pubkey)
 				}
 			}
+			rs.mu.Unlock()
 			ms.mu.Unlock()
 		}
 	}
@@ -793,6 +824,23 @@ func (g *GroupStore) GetMemberCount(h string) int {
 }
 
 func (g *GroupStore) UpdateMembersList(h string) error {
+	// Refuse to publish a snapshot when the in-memory membership for
+	// this group isn't authoritative (e.g. WarmCaches missed its 39002
+	// because of a partial scan). GetMembers gates on the global
+	// cachesWarmed flag and returns an empty list if no cache entry
+	// exists, so without this guard we'd clobber the existing on-disk
+	// 39002 with an empty / partial member list — every subsequent
+	// restart's WarmCaches would load that bad snapshot. Issue #25.
+	//
+	// The next successful WarmCaches will reload the existing 39002
+	// and mark the group fully loaded; the live event handler keeps
+	// the cache in sync from there, and later UpdateMembersList calls
+	// can resume publishing.
+	if _, fullyLoaded := g.membershipFullyLoaded.Load(h); !fullyLoaded {
+		log.Printf("UpdateMembersList: skipping group %q — cache not fully loaded; refusing to publish potentially-partial 39002", h)
+		return nil
+	}
+
 	tags := nostr.Tags{
 		nostr.Tag{"-"},
 		nostr.Tag{"d", h},

--- a/zooid/groups_test.go
+++ b/zooid/groups_test.go
@@ -424,6 +424,79 @@ func TestGroupStore_WarmCaches_StaleAdminsSnapshotDoesNotOverride(t *testing.T) 
 	}
 }
 
+// TestGroupStore_IsMember_PartialWarmFallsBackToDB pins the per-group
+// fully-loaded gating in IsMember. If WarmCaches successfully loaded
+// a 39002 snapshot for one group (groupA) but didn't reach another
+// (groupB) — the partial-read failure mode that motivated #25 — then
+// IsMember(groupB, ...) must NOT trust an empty cache and must fall
+// back to the DB query path for that group. Issue #25 follow-up review.
+func TestGroupStore_IsMember_PartialWarmFallsBackToDB(t *testing.T) {
+	inst := createTestInstance()
+
+	relaySec := inst.Config.secret
+	memberA := nostr.Generate().Public()
+	memberB := nostr.Generate().Public()
+
+	mkAndSave := func(kind nostr.Kind, tags nostr.Tags) {
+		evt := nostr.Event{
+			Kind:      kind,
+			CreatedAt: nostr.Now(),
+			PubKey:    relaySec.Public(),
+			Tags:      tags,
+		}
+		evt.Sign(relaySec)
+		if err := inst.Events.SaveEvent(evt); err != nil {
+			t.Fatalf("SaveEvent(kind=%d): %v", kind, err)
+		}
+	}
+
+	// groupA has a 39002 snapshot — WarmCaches will load it and mark
+	// groupA as fully loaded.
+	mkAndSave(nostr.KindSimpleGroupMembers, nostr.Tags{
+		{"d", "groupA"},
+		{"p", memberA.Hex()},
+	})
+	// groupB has NO 39002 — simulates the partial-read failure mode
+	// (real one would be a query timeout that stopped iteration before
+	// reaching this group). But memberB's membership is recorded as a
+	// kind-9000 put-user that the DB-fallback path queries.
+	mkAndSave(nostr.KindSimpleGroupPutUser, nostr.Tags{
+		{"h", "groupB"},
+		{"p", memberB.Hex()},
+	})
+
+	// Reset and warm.
+	inst.Groups.membershipCache.Range(func(k, _ any) bool {
+		inst.Groups.membershipCache.Delete(k)
+		return true
+	})
+	inst.Groups.membershipFullyLoaded.Range(func(k, _ any) bool {
+		inst.Groups.membershipFullyLoaded.Delete(k)
+		return true
+	})
+	inst.Groups.cachesWarmed = false
+	inst.Groups.WarmCaches()
+
+	// groupA: cache authoritative. memberA in cache → true.
+	if !inst.Groups.IsMember("groupA", memberA) {
+		t.Errorf("memberA should be in cache for groupA after WarmCaches loaded its 39002 snapshot")
+	}
+	// groupA: a non-member must return false from the cache (not from
+	// a DB query). The cache is authoritative for groupA.
+	stranger := nostr.Generate().Public()
+	if inst.Groups.IsMember("groupA", stranger) {
+		t.Errorf("stranger unexpectedly reported as member of groupA")
+	}
+
+	// groupB: WarmCaches didn't load a 39002 → not in
+	// membershipFullyLoaded → IsMember falls back to DB → finds the
+	// kind-9000 put-user → returns true. This is the test that
+	// catches the partial-WarmCaches false-rejection class.
+	if !inst.Groups.IsMember("groupB", memberB) {
+		t.Errorf("memberB should be reported as member via DB fallback (groupB has a kind-9000 put-user but no 39002 was loaded by WarmCaches — partial-read mode must NOT silently false-reject)")
+	}
+}
+
 // TestGroupStore_WarmCaches_StaysPreWarmWhenSnapshotReadsEmpty pins
 // the heuristic that detects a catastrophic warm-up failure (e.g. the
 // snapshot QueryEvents calls timing out under DB pressure): if the

--- a/zooid/groups_test.go
+++ b/zooid/groups_test.go
@@ -273,9 +273,12 @@ func TestGroupStore_ScheduleRewrite_RerunIfDirtyDuringRun(t *testing.T) {
 // returns its error directly.
 func TestGroupStore_ScheduleMembersList_SyncWhenDelayZero(t *testing.T) {
 	g := &GroupStore{DebounceDelay: 0}
-	// No Events store wired up: UpdateMembersList will reach SignAndStoreEvent
-	// and panic. We only assert that scheduling delegates synchronously,
-	// proven by the panic propagating to this goroutine.
+	// UpdateMembersList early-returns for groups whose membership
+	// isn't fully loaded (issue #25 follow-up); mark g1 so the call
+	// proceeds to SignAndStoreEvent and panics on the nil Events.
+	// The panic propagating to this goroutine is what proves the
+	// schedule delegates synchronously.
+	g.membershipFullyLoaded.Store("g1", struct{}{})
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected synchronous call to panic from nil Events; got no panic")
@@ -306,12 +309,15 @@ func TestGroupStore_WarmCaches_FromMembersSnapshot(t *testing.T) {
 	memberB := nostr.Generate().Public()
 	writerPK := nostr.Generate().Public()    // member with role on 39002
 	adminOnlyPK := nostr.Generate().Public() // present in 39001 but not 39002 — must still be a member
-	tailMember := nostr.Generate().Public()  // post-snapshot put
 
-	mkAndSave := func(kind nostr.Kind, tags nostr.Tags) {
+	// Explicit timestamps so the (created_at, id) tiebreak in the
+	// tail-of-log read isn't decided by random id ordering.
+	const snapshotTS = nostr.Timestamp(2000)
+
+	mkAndSave := func(kind nostr.Kind, ts nostr.Timestamp, tags nostr.Tags) {
 		evt := nostr.Event{
 			Kind:      kind,
-			CreatedAt: nostr.Now(),
+			CreatedAt: ts,
 			PubKey:    relaySec.Public(),
 			Tags:      tags,
 		}
@@ -323,7 +329,7 @@ func TestGroupStore_WarmCaches_FromMembersSnapshot(t *testing.T) {
 
 	// kind-39002 (members) — UpdateMembersList shape: roles ride on
 	// the per-member p-tag at positions 2+.
-	mkAndSave(nostr.KindSimpleGroupMembers, nostr.Tags{
+	mkAndSave(nostr.KindSimpleGroupMembers, snapshotTS, nostr.Tags{
 		{"d", groupID},
 		{"p", memberA.Hex()},
 		{"p", memberB.Hex()},
@@ -333,21 +339,15 @@ func TestGroupStore_WarmCaches_FromMembersSnapshot(t *testing.T) {
 	// no role positions. WarmCaches uses this only to ensure listed
 	// admins are visible as members even if the 39002 snapshot is
 	// stale and missed them.
-	mkAndSave(nostr.KindSimpleGroupAdmins, nostr.Tags{
+	mkAndSave(nostr.KindSimpleGroupAdmins, snapshotTS, nostr.Tags{
 		{"d", groupID},
 		{"p", adminOnlyPK.Hex()},
-	})
-	// Tail-of-log put-user that the snapshot doesn't cover yet.
-	// Live updates post-startup would pull this in via the event
-	// handler; warm-up should NOT see it.
-	mkAndSave(nostr.KindSimpleGroupPutUser, nostr.Tags{
-		{"h", groupID},
-		{"p", tailMember.Hex()},
 	})
 
 	// Re-warm caches against the just-saved fixtures.
 	inst.Groups.membershipCache.Delete(groupID)
 	inst.Groups.roleCache.Delete(groupID)
+	inst.Groups.membershipFullyLoaded.Delete(groupID)
 	inst.Groups.cachesWarmed = false
 	inst.Groups.WarmCaches()
 
@@ -366,13 +366,6 @@ func TestGroupStore_WarmCaches_FromMembersSnapshot(t *testing.T) {
 	if !inst.Groups.IsMember(groupID, adminOnlyPK) {
 		t.Errorf("adminOnlyPK missing from cache; admins listed in kind-39001 are implicitly members and must be surfaced even if the 39002 snapshot didn't list them")
 	}
-	// tailMember was added via a kind-9000 saved with nostr.Now(),
-	// the snapshots also use nostr.Now(). With the lag-window-closure
-	// tail-of-log read, events strictly after the snapshot get
-	// applied. In this test the timestamps coincide (same second),
-	// so tailMember is on the boundary — accept either outcome.
-	// The dedicated TestGroupStore_WarmCaches_TailReplaysPostSnapshot
-	// pins the strictly-newer case.
 }
 
 // TestGroupStore_WarmCaches_TailReplaysPostSnapshot verifies the

--- a/zooid/groups_test.go
+++ b/zooid/groups_test.go
@@ -370,3 +370,103 @@ func TestGroupStore_WarmCaches_FromMembersSnapshot(t *testing.T) {
 		t.Errorf("tailMember unexpectedly in cache; warm-up should read snapshots only, not tail of put/remove log")
 	}
 }
+
+// TestGroupStore_WarmCaches_StaleAdminsSnapshotDoesNotOverride locks in
+// the cross-kind staleness rule: a 39001 (admins) snapshot that's
+// strictly older than the 39002 (members) snapshot for the same group
+// must NOT add its listed pubkeys to the membership cache. Otherwise
+// an admin who was demoted+removed (and so dropped from the newer
+// 39002) would get re-added by the older 39001 — exactly the
+// false-acceptance class we'd be trying to avoid in the false-rejection
+// fix. Issue #25 follow-up review.
+func TestGroupStore_WarmCaches_StaleAdminsSnapshotDoesNotOverride(t *testing.T) {
+	inst := createTestInstance()
+	const groupID = "stalegrp"
+
+	relaySec := inst.Config.secret
+	currentMember := nostr.Generate().Public()
+	demotedAndRemoved := nostr.Generate().Public()
+
+	mkAndSave := func(kind nostr.Kind, ts nostr.Timestamp, tags nostr.Tags) {
+		evt := nostr.Event{
+			Kind:      kind,
+			CreatedAt: ts,
+			PubKey:    relaySec.Public(),
+			Tags:      tags,
+		}
+		evt.Sign(relaySec)
+		if err := inst.Events.SaveEvent(evt); err != nil {
+			t.Fatalf("SaveEvent(kind=%d): %v", kind, err)
+		}
+	}
+
+	// Older 39001 with the demoted user still listed.
+	mkAndSave(nostr.KindSimpleGroupAdmins, nostr.Timestamp(1000), nostr.Tags{
+		{"d", groupID},
+		{"p", demotedAndRemoved.Hex()},
+	})
+	// Newer 39002 reflecting current state — only the remaining member.
+	mkAndSave(nostr.KindSimpleGroupMembers, nostr.Timestamp(2000), nostr.Tags{
+		{"d", groupID},
+		{"p", currentMember.Hex()},
+	})
+
+	inst.Groups.membershipCache.Delete(groupID)
+	inst.Groups.roleCache.Delete(groupID)
+	inst.Groups.cachesWarmed = false
+	inst.Groups.WarmCaches()
+
+	if !inst.Groups.IsMember(groupID, currentMember) {
+		t.Errorf("currentMember missing from cache after WarmCaches")
+	}
+	if inst.Groups.IsMember(groupID, demotedAndRemoved) {
+		t.Errorf("demotedAndRemoved is in cache; an older 39001 must not re-add a pubkey that the newer 39002 has dropped")
+	}
+}
+
+// TestGroupStore_WarmCaches_StaysPreWarmWhenSnapshotReadsEmpty pins
+// the heuristic that detects a catastrophic warm-up failure (e.g. the
+// snapshot QueryEvents calls timing out under DB pressure): if the
+// metadata cache shows we have groups but the members/admins reads
+// returned nothing at all, leave cachesWarmed=false so IsMember keeps
+// using its DB query fallback. Issue #25 follow-up review.
+func TestGroupStore_WarmCaches_StaysPreWarmWhenSnapshotReadsEmpty(t *testing.T) {
+	inst := createTestInstance()
+
+	// Save a group metadata event but NO members/admins snapshots.
+	// This simulates the failure mode where the metadata read
+	// succeeded but the snapshot reads came back empty (timeout, db
+	// outage, partial read).
+	relaySec := inst.Config.secret
+	metaEvent := nostr.Event{
+		Kind:      nostr.KindSimpleGroupMetadata,
+		CreatedAt: nostr.Now(),
+		PubKey:    relaySec.Public(),
+		Tags: nostr.Tags{
+			{"d", "lonelygroup"},
+			{"name", "Lonely"},
+		},
+	}
+	metaEvent.Sign(relaySec)
+	if err := inst.Events.SaveEvent(metaEvent); err != nil {
+		t.Fatalf("SaveEvent metadata: %v", err)
+	}
+
+	// Reset everything so WarmCaches runs from scratch against the
+	// just-saved fixture.
+	inst.Groups.metadataCache.Range(func(k, _ any) bool {
+		inst.Groups.metadataCache.Delete(k)
+		return true
+	})
+	inst.Groups.membershipCache.Range(func(k, _ any) bool {
+		inst.Groups.membershipCache.Delete(k)
+		return true
+	})
+	inst.Groups.cachesWarmed = false
+
+	inst.Groups.WarmCaches()
+
+	if inst.Groups.cachesWarmed {
+		t.Errorf("cachesWarmed unexpectedly true: metadata has groups but no membership snapshots were read; should stay in pre-warm mode so IsMember falls back to DB")
+	}
+}

--- a/zooid/groups_test.go
+++ b/zooid/groups_test.go
@@ -366,8 +366,82 @@ func TestGroupStore_WarmCaches_FromMembersSnapshot(t *testing.T) {
 	if !inst.Groups.IsMember(groupID, adminOnlyPK) {
 		t.Errorf("adminOnlyPK missing from cache; admins listed in kind-39001 are implicitly members and must be surfaced even if the 39002 snapshot didn't list them")
 	}
-	if inst.Groups.IsMember(groupID, tailMember) {
-		t.Errorf("tailMember unexpectedly in cache; warm-up should read snapshots only, not tail of put/remove log")
+	// tailMember was added via a kind-9000 saved with nostr.Now(),
+	// the snapshots also use nostr.Now(). With the lag-window-closure
+	// tail-of-log read, events strictly after the snapshot get
+	// applied. In this test the timestamps coincide (same second),
+	// so tailMember is on the boundary — accept either outcome.
+	// The dedicated TestGroupStore_WarmCaches_TailReplaysPostSnapshot
+	// pins the strictly-newer case.
+}
+
+// TestGroupStore_WarmCaches_TailReplaysPostSnapshot verifies the
+// lag-window-closure tail-of-log read in WarmCaches: kind-9000 / 9001
+// events with created_at strictly newer than a group's 39002 snapshot
+// must be applied to the cache during warm-up. Without this, members
+// added (or removed) between the last snapshot emission and a relay
+// restart would stay missing (or stuck) in the cache indefinitely —
+// the live event handler doesn't replay them. Issue #25 follow-up
+// review.
+func TestGroupStore_WarmCaches_TailReplaysPostSnapshot(t *testing.T) {
+	inst := createTestInstance()
+	const groupID = "tailgrp"
+
+	relaySec := inst.Config.secret
+	snapshotMember := nostr.Generate().Public()
+	addedAfterSnapshot := nostr.Generate().Public()
+	removedAfterSnapshot := nostr.Generate().Public()
+
+	mkAndSave := func(kind nostr.Kind, ts nostr.Timestamp, tags nostr.Tags) {
+		evt := nostr.Event{
+			Kind:      kind,
+			CreatedAt: ts,
+			PubKey:    relaySec.Public(),
+			Tags:      tags,
+		}
+		evt.Sign(relaySec)
+		if err := inst.Events.SaveEvent(evt); err != nil {
+			t.Fatalf("SaveEvent(kind=%d): %v", kind, err)
+		}
+	}
+
+	// Snapshot at t=1000 with snapshotMember and removedAfterSnapshot
+	// (the latter will be removed in the tail).
+	mkAndSave(nostr.KindSimpleGroupMembers, nostr.Timestamp(1000), nostr.Tags{
+		{"d", groupID},
+		{"p", snapshotMember.Hex()},
+		{"p", removedAfterSnapshot.Hex()},
+	})
+	// Tail: post-snapshot kind-9000 adding addedAfterSnapshot.
+	mkAndSave(nostr.KindSimpleGroupPutUser, nostr.Timestamp(2000), nostr.Tags{
+		{"h", groupID},
+		{"p", addedAfterSnapshot.Hex()},
+	})
+	// Tail: post-snapshot kind-9001 removing removedAfterSnapshot.
+	mkAndSave(nostr.KindSimpleGroupRemoveUser, nostr.Timestamp(2500), nostr.Tags{
+		{"h", groupID},
+		{"p", removedAfterSnapshot.Hex()},
+	})
+
+	inst.Groups.membershipCache.Range(func(k, _ any) bool {
+		inst.Groups.membershipCache.Delete(k)
+		return true
+	})
+	inst.Groups.membershipFullyLoaded.Range(func(k, _ any) bool {
+		inst.Groups.membershipFullyLoaded.Delete(k)
+		return true
+	})
+	inst.Groups.cachesWarmed = false
+	inst.Groups.WarmCaches()
+
+	if !inst.Groups.IsMember(groupID, snapshotMember) {
+		t.Errorf("snapshotMember missing — should be loaded from kind-39002")
+	}
+	if !inst.Groups.IsMember(groupID, addedAfterSnapshot) {
+		t.Errorf("addedAfterSnapshot missing — kind-9000 newer than the 39002 snapshot must be applied during the tail-of-log read")
+	}
+	if inst.Groups.IsMember(groupID, removedAfterSnapshot) {
+		t.Errorf("removedAfterSnapshot still in cache — kind-9001 newer than the 39002 snapshot must be applied during the tail-of-log read")
 	}
 }
 

--- a/zooid/groups_test.go
+++ b/zooid/groups_test.go
@@ -283,3 +283,80 @@ func TestGroupStore_ScheduleMembersList_SyncWhenDelayZero(t *testing.T) {
 	}()
 	_ = g.ScheduleMembersListUpdate("g1")
 }
+
+// TestGroupStore_WarmCaches_FromMembersSnapshot verifies that the warm-up
+// path reads kind-39002 (members snapshot) and kind-39001 (admins
+// snapshot) instead of replaying the kind-9000/9001 put/remove log.
+// Issue #25.
+//
+// Two assertions:
+//
+//  1. Membership and roles loaded from snapshots end up in the caches.
+//  2. A standalone kind-9000 put-user event NOT reflected in any 39002
+//     is intentionally NOT in the warm cache — the live event handler
+//     would pick it up post-startup, but the warm-up only reads
+//     snapshots. Documents the lag-window tradeoff explicitly so a
+//     future refactor doesn't quietly change it.
+func TestGroupStore_WarmCaches_FromMembersSnapshot(t *testing.T) {
+	inst := createTestInstance()
+	const groupID = "general"
+
+	relaySec := inst.Config.secret
+	memberA := nostr.Generate().Public()
+	memberB := nostr.Generate().Public()
+	adminPK := nostr.Generate().Public()
+	tailMember := nostr.Generate().Public() // post-snapshot put
+
+	mkAndSave := func(kind nostr.Kind, tags nostr.Tags) {
+		evt := nostr.Event{
+			Kind:      kind,
+			CreatedAt: nostr.Now(),
+			PubKey:    relaySec.Public(),
+			Tags:      tags,
+		}
+		evt.Sign(relaySec)
+		if err := inst.Events.SaveEvent(evt); err != nil {
+			t.Fatalf("SaveEvent(kind=%d): %v", kind, err)
+		}
+	}
+
+	// Snapshot of members: A and B.
+	mkAndSave(nostr.KindSimpleGroupMembers, nostr.Tags{
+		{"d", groupID},
+		{"p", memberA.Hex()},
+		{"p", memberB.Hex()},
+	})
+	// Snapshot of admins: adminPK with role "admin".
+	mkAndSave(nostr.KindSimpleGroupAdmins, nostr.Tags{
+		{"d", groupID},
+		{"p", adminPK.Hex(), "admin"},
+	})
+	// Tail-of-log put-user that the snapshot doesn't cover yet.
+	// Real post-startup live updates would pull this in via the event
+	// handler; warm-up should NOT see it.
+	mkAndSave(nostr.KindSimpleGroupPutUser, nostr.Tags{
+		{"h", groupID},
+		{"p", tailMember.Hex()},
+	})
+
+	// Re-warm caches against the just-saved fixtures. createTestInstance
+	// already called WarmCaches before our SaveEvents, so we need to
+	// reset the relevant caches and call it again.
+	inst.Groups.membershipCache.Delete(groupID)
+	inst.Groups.roleCache.Delete(groupID)
+	inst.Groups.cachesWarmed = false
+	inst.Groups.WarmCaches()
+
+	if !inst.Groups.IsMember(groupID, memberA) {
+		t.Errorf("memberA missing from cache after WarmCaches; should have been loaded from kind-39002")
+	}
+	if !inst.Groups.IsMember(groupID, memberB) {
+		t.Errorf("memberB missing from cache")
+	}
+	if inst.Groups.IsMember(groupID, tailMember) {
+		t.Errorf("tailMember unexpectedly in cache; warm-up should read snapshots only, not tail of put/remove log")
+	}
+	if !inst.Groups.HasRole(groupID, adminPK, "admin") {
+		t.Errorf("adminPK role missing from cache; should have been loaded from kind-39001")
+	}
+}

--- a/zooid/groups_test.go
+++ b/zooid/groups_test.go
@@ -304,8 +304,9 @@ func TestGroupStore_WarmCaches_FromMembersSnapshot(t *testing.T) {
 	relaySec := inst.Config.secret
 	memberA := nostr.Generate().Public()
 	memberB := nostr.Generate().Public()
-	adminPK := nostr.Generate().Public()
-	tailMember := nostr.Generate().Public() // post-snapshot put
+	writerPK := nostr.Generate().Public()    // member with role on 39002
+	adminOnlyPK := nostr.Generate().Public() // present in 39001 but not 39002 — must still be a member
+	tailMember := nostr.Generate().Public()  // post-snapshot put
 
 	mkAndSave := func(kind nostr.Kind, tags nostr.Tags) {
 		evt := nostr.Event{
@@ -320,28 +321,31 @@ func TestGroupStore_WarmCaches_FromMembersSnapshot(t *testing.T) {
 		}
 	}
 
-	// Snapshot of members: A and B.
+	// kind-39002 (members) — UpdateMembersList shape: roles ride on
+	// the per-member p-tag at positions 2+.
 	mkAndSave(nostr.KindSimpleGroupMembers, nostr.Tags{
 		{"d", groupID},
 		{"p", memberA.Hex()},
 		{"p", memberB.Hex()},
+		{"p", writerPK.Hex(), "writer"},
 	})
-	// Snapshot of admins: adminPK with role "admin".
+	// kind-39001 (admins) — UpdateAdminsList shape: just `{p, pubkey}`,
+	// no role positions. WarmCaches uses this only to ensure listed
+	// admins are visible as members even if the 39002 snapshot is
+	// stale and missed them.
 	mkAndSave(nostr.KindSimpleGroupAdmins, nostr.Tags{
 		{"d", groupID},
-		{"p", adminPK.Hex(), "admin"},
+		{"p", adminOnlyPK.Hex()},
 	})
 	// Tail-of-log put-user that the snapshot doesn't cover yet.
-	// Real post-startup live updates would pull this in via the event
+	// Live updates post-startup would pull this in via the event
 	// handler; warm-up should NOT see it.
 	mkAndSave(nostr.KindSimpleGroupPutUser, nostr.Tags{
 		{"h", groupID},
 		{"p", tailMember.Hex()},
 	})
 
-	// Re-warm caches against the just-saved fixtures. createTestInstance
-	// already called WarmCaches before our SaveEvents, so we need to
-	// reset the relevant caches and call it again.
+	// Re-warm caches against the just-saved fixtures.
 	inst.Groups.membershipCache.Delete(groupID)
 	inst.Groups.roleCache.Delete(groupID)
 	inst.Groups.cachesWarmed = false
@@ -353,10 +357,16 @@ func TestGroupStore_WarmCaches_FromMembersSnapshot(t *testing.T) {
 	if !inst.Groups.IsMember(groupID, memberB) {
 		t.Errorf("memberB missing from cache")
 	}
+	if !inst.Groups.IsMember(groupID, writerPK) {
+		t.Errorf("writerPK missing from cache; should have been loaded from kind-39002")
+	}
+	if !inst.Groups.HasRole(groupID, writerPK, "writer") {
+		t.Errorf("writerPK role missing; roles ride on kind-39002 p-tag positions 2+")
+	}
+	if !inst.Groups.IsMember(groupID, adminOnlyPK) {
+		t.Errorf("adminOnlyPK missing from cache; admins listed in kind-39001 are implicitly members and must be surfaced even if the 39002 snapshot didn't list them")
+	}
 	if inst.Groups.IsMember(groupID, tailMember) {
 		t.Errorf("tailMember unexpectedly in cache; warm-up should read snapshots only, not tail of put/remove log")
-	}
-	if !inst.Groups.HasRole(groupID, adminPK, "admin") {
-		t.Errorf("adminPK role missing from cache; should have been loaded from kind-39001")
 	}
 }

--- a/zooid/instance.go
+++ b/zooid/instance.go
@@ -495,6 +495,14 @@ func (instance *Instance) OnEventSaved(ctx context.Context, event nostr.Event) {
 
 	if event.Kind == nostr.KindSimpleGroupCreateGroup {
 		instance.Groups.creatorCache.Store(h, event.PubKey)
+		// Brand-new group: there are no pre-existing members beyond
+		// the creator we're about to add. Mark membership as fully
+		// loaded BEFORE AddMember/ScheduleMembersListUpdate run, so
+		// IsMember treats the cache as authoritative for this group
+		// from creation onward and the eventual UpdateMembersList
+		// publishes a correct snapshot the next restart's
+		// WarmCaches will accept. Issue #25.
+		instance.Groups.membershipFullyLoaded.Store(h, struct{}{})
 		if err := instance.Groups.AddMember(h, event.PubKey); err != nil {
 			log.Printf("Failed to add creator %s to group %q: %v", event.PubKey, h, err)
 		}


### PR DESCRIPTION
Fixes #25.

## Why

After the issue-#23 deploy on 2026-05-09, regular members got rejected when posting to groups they had been in for weeks: \`restricted: you are not a member of that group\`. The Grafana \`Group Members\` gauge dropped from ~50k to **23**.

DB was correct — the affected user had a valid kind-9000 add, no kind-9001 remove. The bug was in \`GroupStore.WarmCaches\`, which builds the in-memory \`membershipCache\` at startup by replaying the **full** put/remove log:

\`\`\`go
memberFilter := nostr.Filter{
    Kinds: []nostr.Kind{KindSimpleGroupPutUser, KindSimpleGroupRemoveUser},
}
allEvents := slices.Collect(g.Events.QueryEvents(memberFilter, 0))
\`\`\`

In production that's **90k+ events** (90,024 × kind-9000 + 29 × kind-9001), each with a JSON tag-parse. \`QueryEvents\` is bounded by \`dbOpTimeout = 30s\`. With DB CPU pegged from the prior workload, the iteration ran past the budget mid-replay, \`slices.Collect\` silently returned a partial slice, the loop applied only what it had, and \`g.cachesWarmed = true\` was set unconditionally. \`IsMember\` then trusted the partial cache as authoritative.

## What

WarmCaches now reads the snapshot kinds the relay already maintains:

| Kind | Read for | Production count |
|---|---|---:|
| 39002 (members) | full member set, one event per group | 57 |
| 39001 (admins) | role assignments per NIP-29 p-tag positions | 56 |
| 39000 (metadata) | unchanged — still read | 57 |
| 9007 (creation) | unchanged | 57 |

That's 57 reads instead of 90k, regardless of how many users join in the future. Each addressable-replaceable kind 39001/39002 carries the full current state for one group, so a single read per group is enough.

\"First wins per group\" via local \`seen{Members,Admins}\` maps. NIP-29 says these kinds are addressable-replaceable so the relay normally keeps only one per group, but a stale leftover shouldn't be able to stomp the current state if it ever happens (e.g. during a partial-write incident). \`QueryEvents\` returns events in \`created_at DESC\` order, so the first event we see per group is the newest.

## Verification

- Production \`general\` has one kind-39002 with **48,193** p-tags. Verified via dbops: \`SELECT jsonb_array_length(tags::jsonb) FROM events WHERE kind=39002 ...\` → matches the expected ~50k membership minus a small lag (see below). Reading this snapshot will produce the correct cache.
- \`go test -timeout 300s ./...\` passes; \`gofmt -l -s .\` clean.

## Lag-window tradeoff

Any membership change made between the last 39002 emission for a group and the relay restart is missed by this warm-up. The live event handler in \`groups.go\` updates the cache on each new kind-9000/9001 going forward, so the gap closes as new events arrive.

The 39002 emission pipeline is debounced (\`DebounceDelay\`, see commit \`b998b58\` and the surrounding NIP-29-contention work) — typically a few seconds, occasionally longer under contention. In practice the lag is bounded and active groups close the gap quickly.

If we want this airtight, follow-up: after the snapshot reads, also pull \`kind IN (9000, 9001) AND created_at > min(snapshot.created_at)\` and apply put/remove on top. Returns small numbers (debounce-window-bounded) so it stays fast. Happy to file as #26 if useful.

## Tests

- **Updated** \`cache_test.go::TestGroupMembershipCache_WarmUp\`: writes a kind-39002 fixture instead of replaying AddMember-emitted 9000s.
- **Renamed + rewritten** \`cache_test.go::TestRoleCache_WarmUpFromAdminsSnapshot\` (was \`...FromPutUserEvents\`): writes a kind-39001 with role positions per NIP-29 plus a matching kind-39002.
- **Renamed + rewritten** \`cache_test.go::TestRoleCache_WarmUp_NewerSnapshotWins\` (was \`...RoleReplacement\`): older 39001 must NOT overwrite newer state — locks in first-wins semantics directly.
- **New** \`groups_test.go::TestGroupStore_WarmCaches_FromMembersSnapshot\`: end-to-end. Saves 39002 + 39001 + a tail-of-log kind-9000. Asserts snapshot data loads AND the tail-of-log kind-9000 is NOT in cache after warm-up — pins the lag-window behavior so a future \"secretly add tail handling\" change has to update the test deliberately.

## Out of scope

- E2E canary that would have caught this regression before users felt it. Separate follow-up issue.
- Tail-of-log read in WarmCaches (see lag-window section). Easy to add later if needed.
- Architectural cleanup to make the cache a true optimization (DB-as-source-of-truth + LRU) rather than a correctness requirement. Bigger refactor.